### PR TITLE
test: remove flaky watchdog timing assertion

### DIFF
--- a/tests/unit/test_qwen_agent.py
+++ b/tests/unit/test_qwen_agent.py
@@ -427,8 +427,6 @@ def test_manual_response_control_watchdog_recovers_missing_done(monkeypatch):
             "type": "conversation.item.input_audio_transcription.completed",
             "transcript": "done 丢失后仍需恢复",
         })
-        time.sleep(0.03)
-        assert conv.responses == []
 
         assert _wait_until(lambda: len(conv.responses) == 1)
     finally:


### PR DESCRIPTION
## Summary

- remove a redundant 30ms negative assertion placed immediately before a 40ms real watchdog boundary
- keep the eventual watchdog recovery assertion and the separate no-overlap coverage intact
- make no production-code changes

## Evidence

The merged main run failed only on macOS/Python 3.13 after the loaded runner overslept across the watchdog boundary; its captured warning confirmed that the production watchdog recovered exactly as designed.

## Verification

- `509 passed, 3 skipped`
- `ruff check .` passed
- `mypy` passed for 31 source files
- independent Claude review: APPROVE

Closes #10