### PR TITLE
fix: clear F3 correctness debt

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -95,6 +95,9 @@ DTMF_MODE=inband
 REPEAT_SUPPRESS_SIMILARITY=0.9
 # 外呼最长时长（秒，默认: 150）：LLM 收尾裁判失灵时的最后防线，到点自动道别挂断；0=不限
 OUTBOUND_MAX_SECONDS=150
+# 外呼收尾裁判：接通后首次判断等待与后续判断间隔（隐藏调试项）。
+WRAP_UP_JUDGE_GRACE_SECONDS=20.0
+WRAP_UP_JUDGE_INTERVAL_SECONDS=15.0
 # 通话录音开关（默认: true）
 RECORDING_ENABLED=true
 # 录音保留天数（默认: 30）

--- a/main.py
+++ b/main.py
@@ -9,45 +9,49 @@ import sys
 
 from dotenv import load_dotenv
 
+from agentcall import config
 from agentcall.call_agent import CallAgentService
 
 
-def main() -> None:
-    load_dotenv()
-
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="EG25 来电 AI Agent 服务")
-    parser.add_argument("--port", default=os.getenv("MODEM_PORT", "COM3"))
-    parser.add_argument("--baud", type=int, default=int(os.getenv("MODEM_BAUD", "115200")))
+    parser.add_argument("--port", default=config.get_str("MODEM_PORT"))
+    parser.add_argument("--baud", type=int, default=config.get_int("MODEM_BAUD"))
     parser.add_argument(
         "--audio-keyword",
-        default=os.getenv("MODEM_AUDIO_KEYWORD", "EG25"),
+        default=config.get_str("MODEM_AUDIO_KEYWORD"),
         help="USB 声卡名称关键字",
     )
     parser.add_argument(
         "--audio-mode",
-        choices=["uac", "nmea"],
-        default=os.getenv("MODEM_AUDIO_MODE", "uac"),
+        choices=config.get_spec("MODEM_AUDIO_MODE").choices,
+        default=config.get_str("MODEM_AUDIO_MODE"),
         help="模组音频模式：uac=USB声卡，nmea=USB NMEA串口PCM",
     )
-    parser.add_argument("--pcm-port", default=os.getenv("MODEM_PCM_PORT"))
+    parser.add_argument("--pcm-port", default=config.get_str("MODEM_PCM_PORT"))
     parser.add_argument(
         "--pcm-baud",
         type=int,
-        default=int(os.getenv("MODEM_PCM_BAUD", "921600")),
+        default=config.get_int("MODEM_PCM_BAUD"),
     )
     parser.add_argument(
         "--tx-gain",
         type=float,
-        default=float(os.getenv("MODEM_TX_GAIN", "1.0")),
+        default=config.get_float("MODEM_TX_GAIN"),
         help="写回电话侧的 PCM 音量增益",
     )
     parser.add_argument(
         "--provider",
-        choices=["qwen", "doubao"],
-        default=os.getenv("AGENT_PROVIDER", "qwen"),
+        choices=config.get_spec("AGENT_PROVIDER").choices,
+        default=config.get_str("AGENT_PROVIDER"),
     )
     parser.add_argument("--list-audio", action="store_true", help="列出音频设备后退出")
-    args = parser.parse_args()
+    return parser
+
+
+def main() -> None:
+    load_dotenv()
+    args = build_parser().parse_args()
 
     logging.basicConfig(
         level=logging.INFO,

--- a/src/agentcall/call_agent.py
+++ b/src/agentcall/call_agent.py
@@ -408,7 +408,8 @@ class CallSession:
         # 收尾裁判（仅外呼）：接通后先给 grace 让通话进正题，之后每 interval 让文本模型
         # 看对话判「继续/收尾」——理解任意措辞（治打转/太早撤），不靠关键词枚举。
         judge_enabled = self._outbound_number is not None
-        judge_grace, judge_interval = 20.0, 15.0
+        judge_grace = config.get_float("WRAP_UP_JUDGE_GRACE_SECONDS")
+        judge_interval = config.get_float("WRAP_UP_JUDGE_INTERVAL_SECONDS")
         last_judge_at = loop_started
         goal = self._outbound_task(agent_language()) if judge_enabled else ""
         # 浏览器实时旁听：对方上行电平低，推给浏览器前按此增益放大到可闻。

--- a/src/agentcall/config.py
+++ b/src/agentcall/config.py
@@ -10,10 +10,12 @@ roadmap P2-2/P2-5/P2-6 的地基：
 
 from __future__ import annotations
 
+import codecs
 import logging
 import os
 import re
 import sys
+import threading
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
@@ -23,6 +25,8 @@ from typing import Literal
 from . import platforms
 
 logger = logging.getLogger(__name__)
+
+_ENV_WRITE_LOCK = threading.RLock()
 
 APP_NAME = "CallPilot"
 
@@ -222,6 +226,10 @@ CONFIG_SPECS: tuple[ConfigSpec, ...] = (
     # 外呼硬时限（秒）：LLM 收尾裁判失灵/漏判时的最后防线，到点自动道别挂断；
     # 0 = 不限制。（正常收尾由 summarizer.judge_wrap_up 提前判定。）
     ConfigSpec("OUTBOUND_MAX_SECONDS", "外呼最长时长（秒）", "int", "150"),
+    ConfigSpec("WRAP_UP_JUDGE_GRACE_SECONDS", "收尾裁判首次等待（秒）", "float", "20.0",
+               editable=False, hidden=True),
+    ConfigSpec("WRAP_UP_JUDGE_INTERVAL_SECONDS", "收尾裁判间隔（秒）", "float", "15.0",
+               editable=False, hidden=True),
     ConfigSpec("RECORDING_ENABLED", "通话录音开关", "bool", "true"),
     ConfigSpec("RECORDING_RETENTION_DAYS", "录音保留天数", "int", "30"),
     ConfigSpec("SUMMARY_ENABLED", "通话摘要开关", "bool", "true"),
@@ -518,25 +526,38 @@ def update_env_file(
         return []
 
     path = Path(env_path) if env_path is not None else env_file_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    lines = path.read_text(encoding="utf-8").splitlines() if path.exists() else []
+    with _ENV_WRITE_LOCK:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if path.exists():
+            raw = path.read_bytes()
+            has_bom = raw.startswith(codecs.BOM_UTF8)
+            text = raw.decode("utf-8-sig")
+            newline = "\r\n" if "\r\n" in text else "\n"
+            lines = text.splitlines()
+        else:
+            has_bom = False
+            newline = "\n"
+            lines = []
 
-    replaced: set[str] = set()
-    for i, line in enumerate(lines):
-        match = _ENV_LINE_RE.match(line)
-        if match is None:
-            continue
-        key = match.group(2)
-        if key in updates:
-            lines[i] = f"{match.group(1)}{_format_assignment(key, updates[key])}"
-            replaced.add(key)
-    for key, value in updates.items():
-        if key not in replaced:
-            lines.append(_format_assignment(key, value))
+        replaced: set[str] = set()
+        for i, line in enumerate(lines):
+            match = _ENV_LINE_RE.match(line)
+            if match is None:
+                continue
+            key = match.group(2)
+            if key in updates:
+                lines[i] = f"{match.group(1)}{_format_assignment(key, updates[key])}"
+                replaced.add(key)
+        for key, value in updates.items():
+            if key not in replaced:
+                lines.append(_format_assignment(key, value))
 
-    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-    for key, value in updates.items():
-        os.environ[key] = value
+        rendered = newline.join(lines) + newline
+        if has_bom:
+            rendered = "\ufeff" + rendered
+        path.write_text(rendered, encoding="utf-8", newline="")
+        for key, value in updates.items():
+            os.environ[key] = value
     logger.info("已更新 %s: %s", path, ", ".join(updates))
     return list(updates)
 

--- a/src/agentcall/events.py
+++ b/src/agentcall/events.py
@@ -36,6 +36,7 @@ class EventHub:
         self._clients: set[web.WebSocketResponse] = set()
         self._history: deque[dict[str, Any]] = deque(maxlen=history_limit)
         self._lock = threading.Lock()
+        self._persist_lock = threading.Lock()
         # 推送 task 需持强引用直至完成，否则可能被 GC 提前回收导致 WS 丢事件。
         self._tasks: set[asyncio.Task[None]] = set()
         # 实时旁听：下行 PCM 二进制帧的订阅端（与 JSON 事件端分开，无监听者时零成本）。
@@ -111,10 +112,14 @@ class EventHub:
 
     def publish(self, event: dict[str, Any]) -> None:
         event.setdefault("ts", time.time())
+        should_persist = False
         with self._lock:
             self._history.append(event)
-            if self._store_path and event.get("type") in _PERSISTED_TYPES:
-                self._persist_locked()
+            should_persist = bool(
+                self._store_path and event.get("type") in _PERSISTED_TYPES
+            )
+        if should_persist:
+            self._persist()
         try:
             self._loop.call_soon_threadsafe(self._broadcast, event)
         except RuntimeError:
@@ -174,16 +179,18 @@ class EventHub:
             event["sender"] = sender
             event["text"] = body
 
-    def _persist_locked(self) -> None:
+    def _persist(self) -> None:
         assert self._store_path is not None
-        persisted = [
-            e for e in self._history if e.get("type") in _PERSISTED_TYPES
-        ]
-        try:
-            self._store_path.parent.mkdir(parents=True, exist_ok=True)
-            self._store_path.write_text(
-                json.dumps(persisted, ensure_ascii=False, indent=2),
-                encoding="utf-8",
-            )
-        except OSError as exc:
-            logger.warning("写入短信历史失败: %s", exc)
+        with self._persist_lock:
+            with self._lock:
+                persisted = [
+                    e for e in self._history if e.get("type") in _PERSISTED_TYPES
+                ]
+            try:
+                self._store_path.parent.mkdir(parents=True, exist_ok=True)
+                self._store_path.write_text(
+                    json.dumps(persisted, ensure_ascii=False, indent=2),
+                    encoding="utf-8",
+                )
+            except OSError as exc:
+                logger.warning("写入短信历史失败: %s", exc)

--- a/src/agentcall/modem.py
+++ b/src/agentcall/modem.py
@@ -171,8 +171,9 @@ class Eg25Modem:
         self._closed = False
         self._serial_lock = threading.RLock()
         # 串口重连串行化：多线程（读循环/CLCC 轮询/发送）可能同时发现断连，
-        # 只让一个真正重连，其余等它完成。
+        # 所有获取都遵循 _serial_lock -> _reconnect_lock，禁止反向锁序。
         self._reconnect_lock = threading.Lock()
+        self._reconnect_generation = 0
         # 初始化序列进行中：此时 _send 失败不自触发重连（交给 _reconnect 的重试循环），
         # 避免同线程重入 _reconnect 造成死锁。
         self._opening = False
@@ -250,15 +251,17 @@ class Eg25Modem:
     def _reconnect(self) -> None:
         """串口断连后重开（USB→PTY 桥重插会换新的 /dev/ttys，需重开才能拿到新 fd）。
 
-        多线程可能同时触发，只让第一个真正重连，其余等它完成后返回。
+        多线程可能同时触发，只让第一个真正重连，其余等它完成后返回。锁序固定为
+        ``_serial_lock`` → ``_reconnect_lock``，与拨号/短信/挂断事务一致，避免
+        发送线程持串口锁等待重连锁、读线程反向持锁形成 ABBA 死锁。
         带指数退避重试，直到成功或服务停止。
         """
-        if not self._reconnect_lock.acquire(blocking=False):
-            # 已有线程在重连，等它完成即可。
-            with self._reconnect_lock:
+        observed_generation = self._reconnect_generation
+        with self._serial_lock:
+            # 等串口锁期间若别的线程已完成重连，本次无需重复关闭新连接。
+            if observed_generation != self._reconnect_generation:
                 return
-        try:
-            with self._serial_lock:
+            with self._reconnect_lock:
                 try:
                     if self._ser and self._ser.is_open:
                         self._ser.close()
@@ -266,18 +269,17 @@ class Eg25Modem:
                     pass
                 self._ser = None
                 self._buffer = ""
-            delay = 1.0
-            while self._running and not self._closed:
-                try:
-                    self._open_serial()
-                    logger.info("串口已重连: %s", self._active_port)
-                    return
-                except (serial.SerialException, OSError) as exc:
-                    logger.warning("串口重连失败，%.0fs 后重试: %s", delay, exc)
-                    time.sleep(delay)
-                    delay = min(delay * 2, 10.0)
-        finally:
-            self._reconnect_lock.release()
+                delay = 1.0
+                while self._running and not self._closed:
+                    try:
+                        self._open_serial()
+                        self._reconnect_generation += 1
+                        logger.info("串口已重连: %s", self._active_port)
+                        return
+                    except (serial.SerialException, OSError) as exc:
+                        logger.warning("串口重连失败，%.0fs 后重试: %s", delay, exc)
+                        time.sleep(delay)
+                        delay = min(delay * 2, 10.0)
 
     def _init_sms(self) -> None:
         """开启短信文本模式并让模组主动上报新短信 (+CMTI)。"""

--- a/tests/unit/test_audio_bridge.py
+++ b/tests/unit/test_audio_bridge.py
@@ -4,11 +4,36 @@ from __future__ import annotations
 
 import threading
 
+import numpy as np
 import pytest
 
 import agentcall.audio_bridge as audio_bridge
 import agentcall.coreaudio as coreaudio
-from agentcall.audio_bridge import NMEA_WRITE_SIZE, FfmpegAudioBridge, create_audio_bridge
+from agentcall.audio_bridge import (
+    NMEA_WRITE_SIZE,
+    FfmpegAudioBridge,
+    create_audio_bridge,
+    resample_pcm,
+)
+
+
+@pytest.mark.parametrize("src_rate,dst_rate", [(8000, 24000), (24000, 8000)])
+def test_resample_pcm_round_trip_preserves_length_and_waveform(src_rate, dst_rate):
+    duration = 0.1
+    sample_count = int(src_rate * duration)
+    phase = np.arange(sample_count, dtype=np.float64) / src_rate
+    original = (np.sin(2 * np.pi * 440 * phase) * 12000).astype(np.int16)
+
+    converted = resample_pcm(original.tobytes(), src_rate, dst_rate)
+    restored_bytes = resample_pcm(converted, dst_rate, src_rate)
+    restored = np.frombuffer(restored_bytes, dtype=np.int16)
+
+    assert len(converted) == int(sample_count * dst_rate / src_rate) * 2
+    assert restored.size == original.size
+    assert np.corrcoef(original.astype(np.float64), restored.astype(np.float64))[0, 1] > 0.98
+    assert np.sqrt(np.mean(restored.astype(np.float64) ** 2)) == pytest.approx(
+        np.sqrt(np.mean(original.astype(np.float64) ** 2)), rel=0.05
+    )
 
 
 def make_ffmpeg_bridge() -> FfmpegAudioBridge:

--- a/tests/unit/test_call_wiring.py
+++ b/tests/unit/test_call_wiring.py
@@ -1063,6 +1063,67 @@ def test_supervisor_retries_until_modem_available(monkeypatch):
     assert calls["n"] >= 3
 
 
+def test_supervisor_ready_transition_serializes_ring_and_manual_dial(monkeypatch):
+    """重连刚完成时 RING 与用户外呼并发，只允许一个会话抢占成功。"""
+    modem = FakeModem()
+    service = make_service(modem)
+    service.modem_connected = False
+    monkeypatch.setattr(service, "_credential_errors", lambda: [])
+    starts: list[str | None] = []
+
+    def fake_start(outbound_number=None, **kwargs) -> None:
+        starts.append(outbound_number)
+        service.session._active = True
+
+    monkeypatch.setattr(service.session, "start", fake_start)
+    connected = threading.Event()
+    release_supervisor = threading.Event()
+    original_set_connected = service._set_modem_connected
+
+    def pause_when_connected(value: bool, error: str | None = None) -> None:
+        original_set_connected(value, error)
+        if value:
+            connected.set()
+            release_supervisor.wait(timeout=2)
+
+    monkeypatch.setattr(service, "_set_modem_connected", pause_when_connected)
+    service.start()
+    assert connected.wait(timeout=2)
+
+    race = threading.Barrier(3)
+    dial_result: list[tuple[bool, str | None]] = []
+
+    def ring() -> None:
+        race.wait(timeout=2)
+        modem.trigger_ring("10086")
+
+    def dial() -> None:
+        race.wait(timeout=2)
+        dial_result.append(service.dial("10000"))
+
+    ring_thread = threading.Thread(target=ring, daemon=True)
+    dial_thread = threading.Thread(target=dial, daemon=True)
+    ring_thread.start()
+    dial_thread.start()
+    race.wait(timeout=2)
+    ring_thread.join(timeout=2)
+    dial_thread.join(timeout=2)
+    release_supervisor.set()
+    if service._supervisor_thread:
+        service._supervisor_thread.join(timeout=2)
+    service._service_running = False
+    service.session._active = False
+
+    assert not ring_thread.is_alive() and not dial_thread.is_alive()
+    assert len(starts) == 1
+    assert len(dial_result) == 1
+    if starts[0] is None:
+        assert dial_result[0][0] is False
+    else:
+        assert starts[0] == "10000"
+        assert dial_result[0][0] is True
+
+
 def test_stop_service_halts_supervisor():
     modem = FakeModem()
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import codecs
 import os
 import re
+import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -325,6 +328,67 @@ def test_update_quotes_value_with_spaces(tmp_path, monkeypatch):
     assert os.environ["MONITOR_OUTPUT_DEVICE"] == "MacBook Air 扬声器"
 
 
+def test_update_env_file_concurrent_writers_do_not_lose_keys(
+    tmp_path, monkeypatch
+):
+    keys = {
+        "QWEN_VOICE": "Raymond",
+        "MODEM_TX_GAIN": "0.75",
+        "SUMMARY_MODEL": "qwen-plus",
+        "MONITOR_OUTPUT_DEVICE": "Built-in Output",
+    }
+    _unset(monkeypatch, *keys)
+    env = tmp_path / ".env"
+    env.write_text("# concurrent updates\n", encoding="utf-8")
+    original_write_text = Path.write_text
+
+    def slow_write_text(path, data, *args, **kwargs):
+        if path == env:
+            time.sleep(0.03)
+        return original_write_text(path, data, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", slow_write_text)
+    start = threading.Barrier(len(keys) + 1)
+    errors: list[Exception] = []
+
+    def writer(key: str, value: str) -> None:
+        try:
+            start.wait(timeout=2)
+            update_env_file({key: value}, env_path=env)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=writer, args=item, daemon=True)
+        for item in keys.items()
+    ]
+    for thread in threads:
+        thread.start()
+    start.wait(timeout=2)
+    for thread in threads:
+        thread.join(timeout=2)
+
+    assert not errors
+    assert all(not thread.is_alive() for thread in threads)
+    text = env.read_text(encoding="utf-8")
+    for key, value in keys.items():
+        assert f"{key}={config._format_assignment(key, value).split('=', 1)[1]}" in text
+
+
+def test_update_env_file_handles_utf8_bom_and_preserves_crlf(tmp_path, monkeypatch):
+    _unset(monkeypatch, "QWEN_VOICE")
+    env = tmp_path / ".env"
+    env.write_bytes(codecs.BOM_UTF8 + b"QWEN_VOICE=Cherry\r\n# keep\r\n")
+
+    update_env_file({"QWEN_VOICE": "Raymond"}, env_path=env)
+
+    raw = env.read_bytes()
+    assert raw.startswith(codecs.BOM_UTF8)
+    assert b"QWEN_VOICE=Raymond\r\n" in raw
+    assert b"QWEN_VOICE=Cherry" not in raw
+    assert raw.count(b"QWEN_VOICE=") == 1
+
+
 # ---- read_panel_values ----
 
 
@@ -417,7 +481,8 @@ def test_registered_defaults_match_original_call_sites(monkeypatch):
     """本轮收口的配置项，注册表默认值必须与原调用点硬编码一致。"""
     _unset(monkeypatch, "MODEM_PCM_PORT", "MODEM_PCM_BAUD", "SUMMARY_TIMEOUT",
            "QWEN_PREWARM_TIMEOUT", "QWEN_PREWARM_INTERVAL", "DASHSCOPE_REALTIME_URL",
-           "REPEAT_SUPPRESS_SIMILARITY")
+           "REPEAT_SUPPRESS_SIMILARITY", "WRAP_UP_JUDGE_GRACE_SECONDS",
+           "WRAP_UP_JUDGE_INTERVAL_SECONDS")
     assert get_str("MODEM_PCM_PORT") == ""            # app.py 原 os.getenv 无默认
     assert get_int("MODEM_PCM_BAUD") == 921600        # app.py 原硬编码 "921600"
     assert get_float("SUMMARY_TIMEOUT") == pytest.approx(30.0)   # summarizer 原 "30"
@@ -425,6 +490,15 @@ def test_registered_defaults_match_original_call_sites(monkeypatch):
     assert get_float("QWEN_PREWARM_INTERVAL") == pytest.approx(240.0)  # 原函数入参默认
     assert get_str("DASHSCOPE_REALTIME_URL") == ""    # 留空走 SDK 内置端点
     assert get_float("REPEAT_SUPPRESS_SIMILARITY") == pytest.approx(0.9)
+    assert get_float("WRAP_UP_JUDGE_GRACE_SECONDS") == pytest.approx(20.0)
+    assert get_float("WRAP_UP_JUDGE_INTERVAL_SECONDS") == pytest.approx(15.0)
+    assert get_spec("WRAP_UP_JUDGE_GRACE_SECONDS").hidden
+    assert get_spec("WRAP_UP_JUDGE_INTERVAL_SECONDS").hidden
+    example = (Path(__file__).resolve().parents[2] / ".env.example").read_text(
+        encoding="utf-8"
+    )
+    assert "WRAP_UP_JUDGE_GRACE_SECONDS=20.0" in example
+    assert "WRAP_UP_JUDGE_INTERVAL_SECONDS=15.0" in example
 
 
 def test_editable_specs_covered_by_env_example():

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+import threading
+from pathlib import Path
 
 from agentcall.events import EventHub
 
@@ -33,6 +35,46 @@ def test_sms_events_persisted_and_reloaded(tmp_path):
 
     reloaded = EventHub(make_loop(), store_path=store)
     assert [e["type"] for e in reloaded.history()] == ["sms_in"]
+
+
+def test_persist_write_does_not_hold_history_lock(tmp_path, monkeypatch):
+    store = tmp_path / "messages.json"
+    hub = EventHub(make_loop(), store_path=store)
+    write_started = threading.Event()
+    release_write = threading.Event()
+    second_publish_done = threading.Event()
+    original_write_text = Path.write_text
+
+    def blocked_write(path, data, *args, **kwargs):
+        if path == store:
+            write_started.set()
+            release_write.wait(timeout=2)
+        return original_write_text(path, data, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "write_text", blocked_write)
+    persist_thread = threading.Thread(
+        target=hub.publish,
+        args=({"type": "sms_in", "sender": "10086", "text": "hello"},),
+        daemon=True,
+    )
+    persist_thread.start()
+    assert write_started.wait(timeout=1)
+
+    publish_thread = threading.Thread(
+        target=lambda: (
+            hub.publish({"type": "system", "text": "still responsive"}),
+            second_publish_done.set(),
+        ),
+        daemon=True,
+    )
+    publish_thread.start()
+    completed_without_disk = second_publish_done.wait(timeout=0.2)
+    release_write.set()
+    persist_thread.join(timeout=1)
+    publish_thread.join(timeout=1)
+
+    assert completed_without_disk, "磁盘写入期间 publish 热路径被 history lock 阻塞"
+    assert [event["type"] for event in hub.history()] == ["sms_in", "system"]
 
 
 def test_broadcast_tasks_referenced_until_done():

--- a/tests/unit/test_main_entry.py
+++ b/tests/unit/test_main_entry.py
@@ -1,0 +1,68 @@
+"""精简 CLI 入口的配置注册表接线测试。"""
+
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+
+from agentcall import config
+
+
+def _load_parser():
+    main_path = Path(__file__).resolve().parents[2] / "main.py"
+    namespace = runpy.run_path(str(main_path), run_name="callpilot_main_test")
+    return namespace["build_parser"]()
+
+
+def test_cli_fallback_defaults_match_config_registry(monkeypatch):
+    keys = (
+        "MODEM_PORT",
+        "MODEM_BAUD",
+        "MODEM_AUDIO_KEYWORD",
+        "MODEM_AUDIO_MODE",
+        "MODEM_PCM_PORT",
+        "MODEM_PCM_BAUD",
+        "MODEM_TX_GAIN",
+        "AGENT_PROVIDER",
+    )
+    for key in keys:
+        monkeypatch.delenv(key, raising=False)
+
+    args = _load_parser().parse_args([])
+
+    assert args.port == config.get_str("MODEM_PORT")
+    assert args.baud == config.get_int("MODEM_BAUD")
+    assert args.audio_keyword == config.get_str("MODEM_AUDIO_KEYWORD")
+    assert args.audio_mode == config.get_str("MODEM_AUDIO_MODE")
+    assert args.pcm_port == config.get_str("MODEM_PCM_PORT")
+    assert args.pcm_baud == config.get_int("MODEM_PCM_BAUD")
+    assert args.tx_gain == config.get_float("MODEM_TX_GAIN")
+    assert args.provider == config.get_str("AGENT_PROVIDER")
+
+
+def test_cli_defaults_come_from_config_registry(monkeypatch):
+    values = {
+        "MODEM_PORT": "registry-port",
+        "MODEM_BAUD": "57600",
+        "MODEM_AUDIO_KEYWORD": "registry-audio",
+        "MODEM_AUDIO_MODE": "nmea",
+        "MODEM_PCM_PORT": "registry-pcm",
+        "MODEM_PCM_BAUD": "460800",
+        "MODEM_TX_GAIN": "0.7",
+        "AGENT_PROVIDER": "openai",
+    }
+    for key, value in values.items():
+        monkeypatch.setenv(key, value)
+
+    parser = _load_parser()
+    args = parser.parse_args([])
+
+    assert args.port == "registry-port"
+    assert args.baud == 57600
+    assert args.audio_keyword == "registry-audio"
+    assert args.audio_mode == "nmea"
+    assert args.pcm_port == "registry-pcm"
+    assert args.pcm_baud == 460800
+    assert args.tx_gain == 0.7
+    assert args.provider == "openai"
+    assert parser.parse_args(["--audio-mode", "uac_ffmpeg"]).audio_mode == "uac_ffmpeg"

--- a/tests/unit/test_modem_parsing.py
+++ b/tests/unit/test_modem_parsing.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import threading
 import time
 
+import serial
+
 from agentcall.modem import Eg25Modem, parse_sms_pdu
 
 
@@ -259,6 +261,116 @@ class FakeSerial:
     def reset_input_buffer(self) -> None:
         with self._lock:
             self._pending = b""
+
+    def close(self) -> None:
+        self.is_open = False
+
+
+class TrackingRLock:
+    """RLock wrapper that exposes when a named thread starts waiting for it."""
+
+    def __init__(self, watched_thread: str) -> None:
+        self._lock = threading.RLock()
+        self._watched_thread = watched_thread
+        self.waiting = threading.Event()
+
+    def acquire(self, blocking: bool = True, timeout: float = -1) -> bool:
+        if threading.current_thread().name == self._watched_thread:
+            self.waiting.set()
+        return self._lock.acquire(blocking, timeout)
+
+    def release(self) -> None:
+        self._lock.release()
+
+    def __enter__(self):
+        self.acquire()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.release()
+
+
+def test_send_and_reader_reconnect_do_not_deadlock_on_opposite_lock_order(monkeypatch):
+    """发送线程持串口锁失败时，与读线程并发重连不得形成 ABBA 死锁。"""
+    modem = make_modem()
+    serial_lock = TrackingRLock("reader-reconnect")
+    modem._serial_lock = serial_lock  # type: ignore[assignment]
+    modem._ser = FakeSerial()
+    modem._running = True
+    write_calls = 0
+    open_calls = 0
+    results: list[str] = []
+
+    def flaky_write(_cmd: str) -> str:
+        nonlocal write_calls
+        write_calls += 1
+        if write_calls == 1:
+            raise serial.SerialException("forced write failure")
+        return "OK"
+
+    def reopen() -> None:
+        nonlocal open_calls
+        open_calls += 1
+        modem._ser = FakeSerial()
+
+    monkeypatch.setattr(modem, "_write_command", flaky_write)
+    monkeypatch.setattr(modem, "_open_serial", reopen)
+
+    sender_holds_serial = threading.Event()
+
+    def sender() -> None:
+        with modem._serial_lock:
+            sender_holds_serial.set()
+            assert serial_lock.waiting.wait(timeout=1)
+            results.append(modem._send("AT"))
+
+    sender_thread = threading.Thread(target=sender, name="sender", daemon=True)
+    sender_thread.start()
+    assert sender_holds_serial.wait(timeout=1)
+
+    reader_thread = threading.Thread(
+        target=modem._reconnect, name="reader-reconnect", daemon=True
+    )
+    reader_thread.start()
+
+    sender_thread.join(timeout=1)
+    reader_thread.join(timeout=1)
+    modem._running = False
+
+    assert not sender_thread.is_alive(), "发送线程与读线程发生 ABBA 死锁"
+    assert not reader_thread.is_alive(), "重连线程未能退出"
+    assert results == ["OK"]
+    assert open_calls == 1
+
+
+def test_reconnect_state_machine_retries_and_replaces_serial(monkeypatch):
+    modem = make_modem()
+    old_serial = FakeSerial()
+    modem._ser = old_serial
+    modem._buffer = "stale URC"
+    modem._running = True
+    attempts = 0
+    delays: list[float] = []
+
+    def flaky_open() -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise serial.SerialException("bridge not ready")
+        modem._ser = FakeSerial()
+
+    monkeypatch.setattr(modem, "_open_serial", flaky_open)
+    monkeypatch.setattr("agentcall.modem.time.sleep", delays.append)
+
+    modem._reconnect()
+    modem._running = False
+
+    assert old_serial.is_open is False
+    assert modem._ser is not old_serial
+    assert modem._ser is not None and modem._ser.is_open
+    assert modem._buffer == ""
+    assert attempts == 3
+    assert delays == [1.0, 2.0]
 
 
 def test_hangup_commands_not_interleaved_by_concurrent_send():

--- a/tests/unit/test_summarizer.py
+++ b/tests/unit/test_summarizer.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import threading
+import time
 from types import SimpleNamespace
 
 import dashscope
@@ -104,6 +106,27 @@ def test_api_exception_returns_error(monkeypatch):
     assert result["ok"] is False
     assert "network down" in result["error"]
     assert result["urgency"] == "中"  # 兜底结果仍是完整契约结构
+
+
+def test_summary_timeout_returns_before_slow_api_finishes(monkeypatch):
+    started = threading.Event()
+    release = threading.Event()
+
+    def slow_call(**kwargs):
+        started.set()
+        release.wait(timeout=2)
+        return make_response(json.dumps(GOOD_PAYLOAD, ensure_ascii=False))
+
+    monkeypatch.setattr(dashscope.Generation, "call", staticmethod(slow_call))
+    began = time.monotonic()
+    result = summarize_call(TRANSCRIPTS, "inbound", None, timeout=0.03)
+    elapsed = time.monotonic() - began
+    release.set()
+
+    assert started.is_set()
+    assert elapsed < 0.5
+    assert result["ok"] is False
+    assert "超时" in result["error"]
 
 
 def test_non_200_status_returns_error(monkeypatch):


### PR DESCRIPTION
## Summary

- eliminate the modem reconnect ABBA deadlock by enforcing `_serial_lock -> _reconnect_lock`, coalescing concurrent reconnect attempts by generation, and adding a deterministic two-thread regression test
- add direct coverage for reconnect retries, summarizer timeout, supervisor RING/dial contention, 8k/24k PCM round trips, and concurrent/BOM/CRLF `.env` updates
- move EventHub disk persistence outside the history lock while preserving serialized latest snapshots
- register wrap-up judge timing, synchronize `.env.example`, and route the compact CLI defaults/choices through the config registry

## Verification

- `.venv/bin/pytest -q`: 520 passed, 3 skipped
- `.venv/bin/ruff check .`: passed
- `.venv/bin/mypy`: passed for 31 source files
- `.venv/bin/mypy --platform win32`: passed for 31 source files
- added-lines sensitive-data scan: clean
- implementation isolated in `/Users/tianye/AgentCall-f3`; no changes to `tray_app.py` or `macos_launchd.py`

Closes #13