### PR TITLE
fix: refresh cached remote dialer assets

### DIFF
--- a/src/agentcall/web/static/remote_dialer.html
+++ b/src/agentcall/web/static/remote_dialer.html
@@ -9,13 +9,13 @@
   <title>CallPilot Remote</title>
   <link rel="manifest" href="/manifest.webmanifest">
   <link rel="apple-touch-icon" href="/callpilot-192.png">
-  <link rel="stylesheet" href="/remote_dialer.css">
+  <link rel="stylesheet" href="/remote_dialer.css?v=2">
   <script
     defer
     src="https://cdn.jsdelivr.net/npm/livekit-client@2.20.1/dist/livekit-client.umd.min.js"
     integrity="sha384-IGu2q4tt1II4yly/zsJYCCLP+lffK6+KqCYd4wvwv7cEzBcULk1wHM1fKzBOLrqY"
     crossorigin="anonymous"></script>
-  <script defer src="/remote_dialer.js"></script>
+  <script defer src="/remote_dialer.js?v=2"></script>
 </head>
 <body>
   <main class="dialer-shell">

--- a/src/agentcall/web/static/remote_dialer.js
+++ b/src/agentcall/web/static/remote_dialer.js
@@ -425,7 +425,9 @@
   }
 
   if ("serviceWorker" in navigator) {
-    navigator.serviceWorker.register("/remote_dialer_sw.js").catch(() => {});
+    navigator.serviceWorker.register("/remote_dialer_sw.js?v=2", {
+      updateViaCache: "none",
+    }).catch(() => {});
   }
   initialize();
 })();

--- a/src/agentcall/web/static/remote_dialer_sw.js
+++ b/src/agentcall/web/static/remote_dialer_sw.js
@@ -1,24 +1,28 @@
 "use strict";
 
-const CACHE_NAME = "callpilot-remote-v1";
+const CACHE_NAME = "callpilot-remote-v2";
 const SHELL = [
   "/",
-  "/remote_dialer.css",
-  "/remote_dialer.js",
+  "/remote_dialer.css?v=2",
+  "/remote_dialer.js?v=2",
   "/manifest.webmanifest",
   "/callpilot-192.png",
   "/callpilot-512.png",
 ];
 
 self.addEventListener("install", (event) => {
-  event.waitUntil(caches.open(CACHE_NAME).then((cache) => cache.addAll(SHELL)));
+  event.waitUntil(
+    caches.open(CACHE_NAME)
+      .then((cache) => cache.addAll(SHELL))
+      .then(() => self.skipWaiting()),
+  );
 });
 
 self.addEventListener("activate", (event) => {
   event.waitUntil(
     caches.keys().then((keys) => Promise.all(
       keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)),
-    )),
+    )).then(() => self.clients.claim()),
   );
 });
 

--- a/tests/unit/test_web_static.py
+++ b/tests/unit/test_web_static.py
@@ -154,7 +154,15 @@ def test_remote_dialer_supports_cookie_pairing_fixed_entry_and_pwa_without_brows
     assert "localStorage" not in script
     assert "sessionStorage" not in script
     assert "document.cookie" not in script
-    assert 'navigator.serviceWorker.register("/remote_dialer_sw.js")' in script
+    assert 'navigator.serviceWorker.register("/remote_dialer_sw.js?v=2"' in script
+    assert 'updateViaCache: "none"' in script
+    assert 'href="/remote_dialer.css?v=2"' in html
+    assert 'src="/remote_dialer.js?v=2"' in html
+    assert 'const CACHE_NAME = "callpilot-remote-v2"' in service_worker
+    assert '"/remote_dialer.css?v=2"' in service_worker
+    assert '"/remote_dialer.js?v=2"' in service_worker
+    assert "self.skipWaiting()" in service_worker
+    assert "self.clients.claim()" in service_worker
     assert '"start_url": "/"' in manifest
     assert '"src": "/callpilot-192.png"' in manifest
     assert '"src": "/callpilot-512.png"' in manifest


### PR DESCRIPTION
Closes #39

## What changed

- version the Remote Web Dialer CSS, JavaScript, and Service Worker URLs
- bypass the HTTP cache when checking for Service Worker updates
- bump the offline shell cache to v2 and immediately activate/claim the replacement worker
- align precached shell URLs with the versioned assets
- add static regression assertions for the cache-upgrade contract

## Root cause

An iPhone retained the pre-pairing JavaScript in its Service Worker cache after #33 deployed. Request tracing showed that the phone loaded `/` but did not fetch the updated JS/CSS, so it continued to show the legacy one-time dialer.

## Validation

- real iPhone pairing retest passed
- `686 passed, 3 skipped`
- `ruff check .` passed
- `mypy` passed
- Claude Code review found no P0/P1 issues; its P2 suggestion to version the precached shell URLs was applied