### PR TITLE
fix: restart launchd-managed service cleanly

### DIFF
--- a/app.py
+++ b/app.py
@@ -33,6 +33,28 @@ def _open_browser_later(url: str, delay: float = 1.0) -> threading.Timer | None:
     return timer
 
 
+def _restart_after_cleanup() -> None:
+    """Restart manually-run services in place; let launchd restart its own job.
+
+    Re-executing the frozen child underneath ``caffeinate`` can race a second
+    launchd instance for the listening port.  A launchd-managed service instead
+    exits only after cleanup has released its sockets; ``KeepAlive`` then starts
+    one fresh job with the persisted environment file.
+    """
+    if sys.platform == "darwin":
+        from agentcall.macos_launchd import APP_LABEL
+
+        if os.environ.get("XPC_SERVICE_NAME") == APP_LABEL:
+            logging.getLogger("app").info("清理完成，退出并交由 launchd 重新启动服务…")
+            return
+    argv = (
+        [sys.executable, *sys.argv[1:]]
+        if config._is_frozen()
+        else [sys.executable, *sys.argv]
+    )
+    os.execv(sys.executable, argv)
+
+
 def _force_utf8() -> None:
     """把标准输出改成 UTF-8，避免中文日志乱码（Windows GBK 控制台）。"""
     for stream in (sys.stdout, sys.stderr):
@@ -185,7 +207,7 @@ def main() -> None:
         dial_whitelist or "未设置(全部放行)",
     )
 
-    # 需重启配置的自愈重启：/api/restart 置位该事件 → 停 loop → 清理后 os.execv。
+    # 需重启配置的自愈重启：/api/restart 置位该事件 → 停 loop → 清理后重启。
     restart_event = threading.Event()
     app = build_app(
         hub,
@@ -248,10 +270,11 @@ def main() -> None:
         loop.run_until_complete(runner.cleanup())
         loop.close()
 
-    # 端口已随 runner.cleanup() 释放；此时原地重启（重读 .env）可干净重新绑定。
+    # 端口已随 runner.cleanup() 释放；手动运行原地 exec，launchd 运行则退出交由
+    # KeepAlive 拉起，避免 frozen 子进程与 launchd 新实例争抢同一端口。
     if restart_event.is_set():
         logger.info("按请求重启服务以应用需重启的配置…")
-        os.execv(sys.executable, [sys.executable, *sys.argv])
+        _restart_after_cleanup()
 
 
 def _selftest() -> int:

--- a/desktop_app.py
+++ b/desktop_app.py
@@ -5,8 +5,8 @@
 启动流程：
     1. 探测 ``<AGENTCALL_WEB_URL>/api/meta`` 判断服务是否已在运行；
     2. 在跑 → 直接开窗指向服务地址；
-    3. 没跑 → 用项目 venv 的 python 拉起 app.py（stdout/stderr 追加到
-       ``data/app_console.log``），轮询等待就绪后开窗；
+    3. 没跑 → 打包版 macOS 等待 launchd 拉起；其他运行方式用项目 venv 的
+       python 拉起 app.py（stdout/stderr 追加到 ``data/app_console.log``）；
     4. 拉起失败或等待超时 → 开一个错误提示窗，说明手动启动命令。
 
 用法：
@@ -110,6 +110,12 @@ def _launch_config() -> tuple[str, str, str]:
     return python_exe, app_script, log_path
 
 
+def _bundled_macos_service_is_system_managed() -> bool:
+    """Return whether launchd, rather than this window, owns the service."""
+    frozen = bool(getattr(sys, "frozen", False) or getattr(sys, "_MEIPASS", None))
+    return platforms.IS_MACOS and frozen
+
+
 # ---- 纯逻辑（可单测）----
 
 def probe_service(url: str, timeout: float = 2.0) -> bool:
@@ -182,6 +188,22 @@ def ensure_service_running(
     if probe_service(meta_url, timeout=probe_timeout):
         logger.info("服务已在运行: %s", meta_url)
         return "already"
+
+    # The bundled tray installs a KeepAlive launchd job before opening this
+    # window. Spawning another --service process during launchd startup/restart
+    # races both instances for WEB_PORT and can leave the old configuration live.
+    if _bundled_macos_service_is_system_managed():
+        logger.info("服务暂未就绪，等待 launchd 托管实例启动: %s", meta_url)
+        return (
+            "started"
+            if wait_service_ready(
+                meta_url,
+                max_wait=max_wait,
+                interval=poll_interval,
+                probe_timeout=probe_timeout,
+            )
+            else "failed"
+        )
 
     log_file = Path(log_path)
     try:

--- a/src/agentcall/web/server.py
+++ b/src/agentcall/web/server.py
@@ -234,7 +234,7 @@ def build_app(
     app["modem"] = modem
     app["service"] = service
     app["meta"] = meta or {}
-    # 由 app.py 传入的 threading.Event；置位后主循环停止并 os.execv 自重启。
+    # 由 app.py 传入的 threading.Event；置位后主循环停止、清理并按运行方式重启。
     app["restart_event"] = restart_event
     app["setup_sms_token"] = [secrets.token_urlsafe(24)]
     app["remote_pairing_store"] = remote_pairing_store
@@ -954,8 +954,9 @@ async def _setup_test_sms(request: web.Request) -> web.Response:
 async def _restart(request: web.Request) -> web.Response:
     """重启服务以应用需重启的配置。
 
-    置位 restart_event 后延迟停止事件循环——app.py 主循环随即清理并
-    os.execv 原地重启（重读 .env）。延迟 0.4s 是为了让本响应先发回前端。
+    置位 restart_event 后延迟停止事件循环——app.py 主循环随即清理；手动运行
+    原地 exec，launchd 管理时退出交由 KeepAlive 拉起。延迟 0.4s 是为了让本响应
+    先发回前端。
     """
     restart_event = request.app.get("restart_event")
     if restart_event is None:

--- a/tests/unit/test_app_entry.py
+++ b/tests/unit/test_app_entry.py
@@ -54,3 +54,41 @@ def test_open_browser_later_opens_browser_in_source_mode(monkeypatch):
     assert timer.delay == 0.25
     assert timer.started is True
     assert opened == ["http://127.0.0.1:47100"]
+
+
+def test_restart_after_cleanup_exits_for_launchd_managed_service(monkeypatch):
+    calls = []
+    monkeypatch.setattr(app.sys, "platform", "darwin")
+    monkeypatch.setenv("XPC_SERVICE_NAME", "com.agentcall.app")
+    monkeypatch.setattr(app.os, "execv", lambda *args: calls.append(args))
+
+    app._restart_after_cleanup()
+
+    assert calls == []
+
+
+def test_restart_after_cleanup_execs_manual_process_without_duplicate_argv0(monkeypatch):
+    calls = []
+    monkeypatch.setattr(app.sys, "platform", "darwin")
+    monkeypatch.delenv("XPC_SERVICE_NAME", raising=False)
+    monkeypatch.setattr(app.config, "_is_frozen", lambda: True)
+    monkeypatch.setattr(app.sys, "executable", "/tmp/CallPilot")
+    monkeypatch.setattr(app.sys, "argv", ["/tmp/CallPilot", "--service"])
+    monkeypatch.setattr(app.os, "execv", lambda path, argv: calls.append((path, argv)))
+
+    app._restart_after_cleanup()
+
+    assert calls == [("/tmp/CallPilot", ["/tmp/CallPilot", "--service"])]
+
+
+def test_restart_after_cleanup_preserves_script_for_source_mode(monkeypatch):
+    calls = []
+    monkeypatch.setattr(app.sys, "platform", "linux")
+    monkeypatch.setattr(app.config, "_is_frozen", lambda: False)
+    monkeypatch.setattr(app.sys, "executable", "/tmp/python")
+    monkeypatch.setattr(app.sys, "argv", ["/repo/app.py", "--service"])
+    monkeypatch.setattr(app.os, "execv", lambda path, argv: calls.append((path, argv)))
+
+    app._restart_after_cleanup()
+
+    assert calls == [("/tmp/python", ["/tmp/python", "/repo/app.py", "--service"])]

--- a/tests/unit/test_desktop_app.py
+++ b/tests/unit/test_desktop_app.py
@@ -147,6 +147,21 @@ def test_ensure_already_running(monkeypatch):
     assert desktop_app.ensure_service_running("http://x/api/meta") == "already"
 
 
+def test_ensure_bundled_macos_waits_for_launchd_without_spawning_duplicate(monkeypatch):
+    results = iter([False, False, True])
+    monkeypatch.setattr(
+        desktop_app, "probe_service", lambda url, timeout=2.0: next(results)
+    )
+    monkeypatch.setattr(desktop_app.platforms, "IS_MACOS", True)
+    monkeypatch.setattr(desktop_app.sys, "frozen", True, raising=False)
+    _no_sleep(monkeypatch)
+    _forbid_popen(monkeypatch)
+
+    assert desktop_app.ensure_service_running(
+        "http://x/api/meta", max_wait=5.0, poll_interval=0
+    ) == "started"
+
+
 def test_ensure_starts_service(monkeypatch, tmp_path):
     state = {"up": False}
     monkeypatch.setattr(

--- a/tray_app.py
+++ b/tray_app.py
@@ -7,7 +7,7 @@
 菜单：
     ● CallPilot            （标题，图标随服务状态：🟢 在线 / 🔴 离线）
     打开控制台             （开 pywebview 面板窗口，即 desktop_app.py 子进程）
-    重启服务               （POST /api/restart，原地重启后端）
+    重启服务               （POST /api/restart，按当前运行方式重启后端）
     ——
     退出                   （仅退出托盘；后端服务仍由 launchd 常驻）
 


### PR DESCRIPTION
Closes #32

## Root cause

Historical packaged-app logs show two related races:

- after `/api/restart`, the frozen child re-executed itself and sometimes failed to bind `127.0.0.1:47100` because another service instance already owned the port;
- the bundled desktop window could see the expected restart gap and spawn its own `--service` fallback even though launchd already owned the service lifecycle.

This left the old instance/configuration visible after the API had returned `{ok:true}`.

## Changes

- launchd-managed `com.agentcall.app` now exits only after normal cleanup and lets `KeepAlive` start one fresh job
- manually run source/frozen services retain in-place exec restart with correct argv reconstruction for each runtime
- bundled macOS desktop windows wait for launchd instead of spawning a competing service process
- update restart documentation/comments and add deterministic regression tests

## Validation

- `689 passed, 3 skipped`
- `ruff check .` passed
- `mypy` passed
- `mypy --platform win32` passed
- Claude Code review found and prompted a source-mode argv correction; re-review found no P0/P1 blockers