### PR TITLE
feat: Android App 接入 hosted 云控制面 /v1 协议（#44）

### DIFF
--- a/android/app/src/main/kotlin/ai/bondings/callpilot/call/CallManager.kt
+++ b/android/app/src/main/kotlin/ai/bondings/callpilot/call/CallManager.kt
@@ -4,15 +4,23 @@ import ai.bondings.callpilot.media.RemoteSession
 import ai.bondings.callpilot.media.SessionEvent
 import ai.bondings.callpilot.pairing.StoredPairing
 import ai.bondings.callpilot.protocol.GatewayClient
+import ai.bondings.callpilot.protocol.HostedCallSession
+import ai.bondings.callpilot.protocol.HostedCloudClient
+import ai.bondings.callpilot.protocol.HostedCloudException
 import ai.bondings.callpilot.protocol.Invite
 import ai.bondings.callpilot.protocol.InviteParser
+import ai.bondings.callpilot.protocol.PairingProtocol
 import ai.bondings.callpilot.protocol.Signaling
 import java.util.UUID
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -26,22 +34,30 @@ sealed interface CallState {
     data class Dialing(val number: String) : CallState
     data class InCall(val number: String) : CallState
     data class Ended(val number: String, val reason: String) : CallState
-    data class Failed(val number: String, val reason: String) : CallState
+    data class Failed(val number: String, val reason: String, val code: String? = null) : CallState
 }
 
 /**
  * 出站通话状态机（单通互斥，与 Edge 的一 SIM 一通对应）。
  *
- * 流程：createSession → 解 fragment → 连房间发麦 → 发 dial 命令 →
+ * 流程：按配对来源创建 Tunnel/v1 session → 连房间发麦 → 发 dial 命令 →
  * 收 Edge status/remote_call 事件推进状态 → 任一端挂断/断连收尾（幂等）。
  */
 class CallManager(
     private val sessionFactory: () -> RemoteSession,
-    private val inviteProvider: (StoredPairing) -> Invite = { pairing ->
+    private val inviteProvider: suspend (StoredPairing) -> Invite = { pairing ->
         GatewayClient(pairing.gatewayUrl)
             .also { it.credential = pairing.credential }
             .createSession()
     },
+    private val hostedSessionProvider: suspend (StoredPairing, String) -> HostedCallSession =
+        { pairing, idempotencyKey ->
+            val edgeId = pairing.edgeId ?: error("云配对缺少 Edge ID")
+            HostedCloudClient(pairing.gatewayUrl)
+                .also { it.credential = pairing.credential }
+                .createSession(edgeId, idempotencyKey)
+        },
+    private val idempotencyKeyProvider: () -> String = { "android-${UUID.randomUUID()}" },
     private val onForeground: (active: Boolean) -> Unit = {},
     scope: CoroutineScope? = null,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
@@ -53,6 +69,10 @@ class CallManager(
 
     private var session: RemoteSession? = null
     private var eventJob: Job? = null
+    private var setupJob: Job? = null
+    private var dialJob: Job? = null
+    private var hangupRequested = false
+    private val commandLock = Any()
 
     /** 等待 Edge media_ready 后才发出的 dial 命令（Edge 会拒绝抢跑的 dial）。 */
     private var pendingDial: String? = null
@@ -64,32 +84,42 @@ class CallManager(
 
     fun startCall(pairing: StoredPairing, number: String) {
         if (isActive) return
+        synchronized(commandLock) { hangupRequested = false }
         _state.value = CallState.Preparing(number)
-        scope.launch {
+        val idempotencyKey = idempotencyKeyProvider()
+        setupJob = scope.launch {
             try {
-                val invite = withContext(ioDispatcher) {
-                    inviteProvider(pairing)
-                }
-                val structuredUrl = invite.livekitUrl
-                val structuredToken = invite.token
-                val (livekitUrl, token) =
-                    if (!structuredUrl.isNullOrBlank() && !structuredToken.isNullOrBlank()) {
-                        structuredUrl to structuredToken
-                    } else {
-                        val payload = InviteParser.parseInviteUrl(invite.url)
-                            ?: error("邀请解析失败（协议版本或格式不符）")
-                        payload.url to payload.token
+                val (livekitUrl, token) = withContext(ioDispatcher) {
+                    when (pairing.protocol) {
+                        PairingProtocol.TUNNEL -> connectionFromInvite(inviteProvider(pairing))
+                        PairingProtocol.HOSTED -> hostedSessionProvider(pairing, idempotencyKey).let {
+                            it.livekitUrl to it.token
+                        }
                     }
+                }
                 val s = sessionFactory()
                 session = s
                 eventJob = scope.launch { s.events.collect { handleEvent(number, it) } }
                 onForeground(true)
                 // Edge 在确认本端音频轨就绪（media_ready 事件）前会拒绝 dial，
                 // 所以 dial 挂起到 handleEvent 收到 media_ready 再发。
-                pendingDial = number
+                currentCoroutineContext().ensureActive()
+                synchronized(commandLock) {
+                    if (_state.value !is CallState.Preparing) throw CancellationException()
+                    pendingDial = number
+                }
                 s.connect(livekitUrl, token)
+                currentCoroutineContext().ensureActive()
                 _state.value = CallState.WaitingMedia(number)
+                setupJob = null
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: HostedCloudException) {
+                setupJob = null
+                cleanup()
+                _state.value = CallState.Failed(number, e.message, e.errorCode)
             } catch (e: Exception) {
+                setupJob = null
                 cleanup()
                 _state.value = CallState.Failed(number, e.message ?: "拨号失败")
             }
@@ -113,6 +143,15 @@ class CallManager(
 
     fun hangup() {
         val number = currentNumber() ?: return
+        synchronized(commandLock) {
+            if (hangupRequested) return
+            hangupRequested = true
+            pendingDial = null
+            setupJob?.cancel()
+            setupJob = null
+            dialJob?.cancel()
+            dialJob = null
+        }
         val s = session
         scope.launch {
             try {
@@ -131,6 +170,7 @@ class CallManager(
     }
 
     private fun handleEvent(number: String, event: SessionEvent) {
+        if (!isActive || synchronized(commandLock) { hangupRequested }) return
         when (event) {
             is SessionEvent.Edge -> {
                 // Edge 经 LiveKit data channel 发的是 type=status 事件（#37 契约）；
@@ -166,17 +206,37 @@ class CallManager(
 
     /** media_ready 后才把 dial 发给 Edge（幂等：只发一次）。 */
     private fun firePendingDial() {
-        val number = pendingDial ?: return
-        pendingDial = null
-        val s = session ?: return
-        scope.launch {
-            try {
-                s.sendCommand(Signaling.encodeDial(number, UUID.randomUUID().toString()))
-            } catch (e: Exception) {
-                cleanup()
-                _state.value = CallState.Failed(number, e.message ?: "拨号失败")
+        val job = synchronized(commandLock) {
+            if (hangupRequested ||
+                (_state.value !is CallState.WaitingMedia && _state.value !is CallState.Dialing)
+            ) {
+                return
             }
+            val number = pendingDial ?: return
+            pendingDial = null
+            val s = session ?: return
+            scope.launch(start = CoroutineStart.LAZY) {
+                if (!dialIsActive()) return@launch
+                try {
+                    s.sendCommand(Signaling.encodeDial(number, UUID.randomUUID().toString()))
+                    if (!dialIsActive()) return@launch
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    synchronized(commandLock) { dialJob = null }
+                    cleanup()
+                    _state.value = CallState.Failed(number, e.message ?: "拨号失败")
+                }
+            }.also { dialJob = it }
         }
+        job.start()
+    }
+
+    private fun dialIsActive(): Boolean = synchronized(commandLock) {
+        val state = _state.value
+        !hangupRequested &&
+            (state is CallState.WaitingMedia || state is CallState.Dialing) &&
+            dialJob?.isActive == true
     }
 
     private fun currentNumber(): String? = when (val s = _state.value) {
@@ -187,8 +247,25 @@ class CallManager(
         else -> null
     }
 
+    private fun connectionFromInvite(invite: Invite): Pair<String, String> {
+        val structuredUrl = invite.livekitUrl
+        val structuredToken = invite.token
+        if (!structuredUrl.isNullOrBlank() && !structuredToken.isNullOrBlank()) {
+            return structuredUrl to structuredToken
+        }
+        val payload = InviteParser.parseInviteUrl(invite.url)
+            ?: error("邀请解析失败（协议版本或格式不符）")
+        return payload.url to payload.token
+    }
+
     private fun cleanup() {
-        pendingDial = null
+        synchronized(commandLock) {
+            setupJob?.cancel()
+            setupJob = null
+            dialJob?.cancel()
+            dialJob = null
+            pendingDial = null
+        }
         eventJob?.cancel()
         eventJob = null
         session?.disconnect()

--- a/android/app/src/main/kotlin/ai/bondings/callpilot/pairing/CredentialStore.kt
+++ b/android/app/src/main/kotlin/ai/bondings/callpilot/pairing/CredentialStore.kt
@@ -1,6 +1,7 @@
 package ai.bondings.callpilot.pairing
 
 import ai.bondings.callpilot.protocol.DeviceCredential
+import ai.bondings.callpilot.protocol.PairingProtocol
 import android.content.Context
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
@@ -10,6 +11,8 @@ data class StoredPairing(
     val gatewayUrl: String,
     val displayName: String,
     val credential: DeviceCredential,
+    val protocol: PairingProtocol = PairingProtocol.TUNNEL,
+    val edgeId: String? = null,
 )
 
 class CredentialStore(context: Context) {
@@ -27,6 +30,8 @@ class CredentialStore(context: Context) {
             .putString(KEY_NAME, pairing.displayName)
             .putString(KEY_DEVICE_ID, pairing.credential.deviceId)
             .putString(KEY_SECRET, pairing.credential.secret)
+            .putString(KEY_PROTOCOL, pairing.protocol.storedValue)
+            .putString(KEY_EDGE_ID, pairing.edgeId)
             .apply()
     }
 
@@ -35,7 +40,10 @@ class CredentialStore(context: Context) {
         val deviceId = prefs.getString(KEY_DEVICE_ID, null) ?: return null
         val secret = prefs.getString(KEY_SECRET, null) ?: return null
         val name = prefs.getString(KEY_NAME, "") ?: ""
-        return StoredPairing(gateway, name, DeviceCredential(deviceId, secret))
+        val protocol = PairingProtocol.fromStored(prefs.getString(KEY_PROTOCOL, null))
+        val edgeId = prefs.getString(KEY_EDGE_ID, null)
+        if (protocol == PairingProtocol.HOSTED && edgeId.isNullOrBlank()) return null
+        return StoredPairing(gateway, name, DeviceCredential(deviceId, secret), protocol, edgeId)
     }
 
     /** 解除配对：清凭证但保留最近网关，下次配对免重新粘贴链接。 */
@@ -52,6 +60,8 @@ class CredentialStore(context: Context) {
         const val KEY_NAME = "display_name"
         const val KEY_DEVICE_ID = "device_id"
         const val KEY_SECRET = "secret"
+        const val KEY_PROTOCOL = "protocol"
+        const val KEY_EDGE_ID = "edge_id"
         const val KEY_LAST_GATEWAY = "last_gateway_url"
     }
 }

--- a/android/app/src/main/kotlin/ai/bondings/callpilot/protocol/HostedCloudClient.kt
+++ b/android/app/src/main/kotlin/ai/bondings/callpilot/protocol/HostedCloudClient.kt
@@ -1,0 +1,321 @@
+package ai.bondings.callpilot.protocol
+
+import java.io.IOException
+import java.net.URI
+import java.util.UUID
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+
+/** Hosted control-plane `/v1` adapter. Calls are blocking and must run on an IO dispatcher. */
+class HostedCloudClient(
+    baseUrl: String,
+    private val client: OkHttpClient = OkHttpClient(),
+    private val clockMs: () -> Long = System::currentTimeMillis,
+    private val sleepMs: (Long) -> Unit = Thread::sleep,
+) {
+    companion object {
+        private val JSON_MEDIA = "application/json; charset=utf-8".toMediaType()
+        private val DEVICE_ID = Regex("^device_[A-Za-z0-9_-]{12,80}$")
+        private val EDGE_ID = Regex("^edge_[A-Za-z0-9_-]{12,80}$")
+        private val CALL_ID = Regex("^call_[A-Za-z0-9_-]{12,80}$")
+        private val IDEMPOTENCY_KEY = Regex("^[A-Za-z0-9._:-]{16,128}$")
+    }
+
+    private val base: HttpUrl = baseUrl.toHttpUrl().also {
+        require(it.isHttps || it.host in setOf("localhost", "127.0.0.1", "::1")) {
+            "云控制面地址必须是 https"
+        }
+    }
+    private val origin: String = buildString {
+        append(base.scheme).append("://").append(base.host)
+        if (base.port != HttpUrl.defaultPort(base.scheme)) append(":").append(base.port)
+    }
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Volatile
+    var credential: DeviceCredential? = null
+
+    fun claimPairing(code: String, displayName: String): HostedPairResult {
+        val body = buildJsonObject {
+            put("code", code)
+            put("displayName", displayName)
+        }.toString()
+        request("POST", "v1/pairing-sessions/claim", body).use { response ->
+            val payload = parseOrThrow(response)
+            val device = payload["device"]?.let {
+                json.decodeFromJsonElement(HostedDevice.serializer(), it)
+            } ?: throw HostedCloudException(response.code, "INVALID_RESPONSE", "配对响应缺少 device 字段")
+            val deviceCredential = extractCredential(response)
+                ?: throw HostedCloudException(response.code, "INVALID_RESPONSE", "配对响应缺少设备凭证 Cookie")
+            validateDevice(device, deviceCredential, response.code)
+            credential = deviceCredential
+            return HostedPairResult(device, deviceCredential)
+        }
+    }
+
+    fun deviceStatus(): HostedDeviceStatus {
+        request("GET", "v1/device", null).use { response ->
+            val payload = parseOrThrow(response)
+            val paired = payload["paired"]?.jsonPrimitive?.booleanOrNull ?: false
+            val device = payload["device"]?.let {
+                json.decodeFromJsonElement(HostedDevice.serializer(), it)
+            }
+            if (paired) {
+                validateDevice(
+                    device ?: throw HostedCloudException(
+                        response.code,
+                        "INVALID_RESPONSE",
+                        "设备状态响应缺少 device 字段",
+                    ),
+                    credential,
+                    response.code,
+                )
+            }
+            val edge = payload["edge"]?.jsonObject ?: JsonObject(emptyMap())
+            return HostedDeviceStatus(paired, device, edge)
+        }
+    }
+
+    fun createSession(
+        edgeId: String,
+        idempotencyKey: String = "android-${UUID.randomUUID()}",
+    ): HostedCallSession {
+        require(EDGE_ID.matches(edgeId)) { "云配对缺少有效的 Edge ID" }
+        require(IDEMPOTENCY_KEY.matches(idempotencyKey)) { "idempotency key 格式不合法" }
+        val body = buildJsonObject {
+            put("edgeId", edgeId)
+            put("idempotencyKey", idempotencyKey)
+        }.toString()
+        val created = createCallWithRetry(body, edgeId)
+        throwIfTerminal(created)
+        val pollingStartedAt = clockMs()
+        while (clockMs() < created.expiresAt) {
+            val call = request("GET", "v1/calls/${created.callId}", null).use { response ->
+                decodeCall(parseOrThrow(response), response.code).also {
+                    validateCall(
+                        it,
+                        expectedCallId = created.callId,
+                        expectedEdgeId = edgeId,
+                        statusCode = response.code,
+                    )
+                }
+            }
+            throwIfTerminal(call)
+            call.session?.let {
+                validateSession(it)
+                return HostedCallSession(
+                    sessionId = call.callId,
+                    livekitUrl = it.livekitUrl,
+                    token = it.token,
+                    expiresAt = it.expiresAt,
+                )
+            }
+            val now = clockMs()
+            val remaining = created.expiresAt - now
+            if (remaining <= 0) break
+            val interval = if (now - pollingStartedAt < 3_000) 250L else 1_000L
+            sleepMs(minOf(interval, remaining))
+        }
+        throw HostedCloudException(408, "SESSION_TIMEOUT", "等待云端通话会话超时")
+    }
+
+    fun unpair() {
+        request("DELETE", "v1/device", null).use { response ->
+            parseOrThrow(response)
+            credential = null
+        }
+    }
+
+    private fun request(method: String, path: String, jsonBody: String?): Response {
+        val builder = Request.Builder()
+            .url(base.newBuilder().addPathSegments(path).build())
+            .header("Origin", origin)
+            .header("Accept", "application/json")
+            .header("Cache-Control", "no-store")
+        credential?.let {
+            builder.header("Cookie", "${GatewayClient.DEVICE_COOKIE}=${it.asCookieValue()}")
+        }
+        when (method) {
+            "GET" -> builder.get()
+            "POST" -> builder.post((jsonBody ?: "{}").toRequestBody(JSON_MEDIA))
+            "DELETE" -> builder.delete()
+            else -> error("不支持的方法 $method")
+        }
+        return client.newCall(builder.build()).execute()
+    }
+
+    private fun parseOrThrow(response: Response): JsonObject {
+        val text = response.body?.string().orEmpty()
+        val payload = try {
+            json.parseToJsonElement(text).jsonObject
+        } catch (_: Exception) {
+            throw HostedCloudException(
+                response.code,
+                "INVALID_RESPONSE",
+                "云控制面响应不是合法 JSON（HTTP ${response.code}）",
+            )
+        }
+        if (!response.isSuccessful) {
+            val error = payload["error"]?.jsonObject
+            val code = error?.get("code")?.jsonPrimitive?.contentOrNull ?: "HTTP_${response.code}"
+            val message = error?.get("message")?.jsonPrimitive?.contentOrNull
+                ?: "云控制面请求失败（HTTP ${response.code}）"
+            throw HostedCloudException(response.code, code, message)
+        }
+        return payload
+    }
+
+    private fun decodeCall(payload: JsonObject, statusCode: Int): HostedCallResponse = try {
+        json.decodeFromJsonElement(HostedCallResponse.serializer(), payload)
+    } catch (_: Exception) {
+        throw HostedCloudException(statusCode, "INVALID_RESPONSE", "云端呼叫响应字段不完整")
+    }
+
+    private fun createCallWithRetry(body: String, edgeId: String): HostedCallResponse {
+        repeat(2) { attempt ->
+            try {
+                return request("POST", "v1/calls", body).use { response ->
+                    decodeCall(parseOrThrow(response), response.code).also {
+                        validateCall(it, expectedEdgeId = edgeId, statusCode = response.code)
+                    }
+                }
+            } catch (e: IOException) {
+                if (attempt == 1) throw e
+            }
+        }
+        error("unreachable")
+    }
+
+    private fun validateCall(
+        call: HostedCallResponse,
+        expectedCallId: String? = null,
+        expectedEdgeId: String,
+        statusCode: Int,
+    ) {
+        val validCallId = CALL_ID.matches(call.callId)
+        val matchesRequest = call.edgeId == expectedEdgeId &&
+            (expectedCallId == null || call.callId == expectedCallId)
+        val validSessionState = call.session == null || call.status == "ready"
+        if (!validCallId || !matchesRequest || !validSessionState) {
+            throw HostedCloudException(statusCode, "INVALID_RESPONSE", "云端呼叫响应内容不合法")
+        }
+    }
+
+    private fun validateDevice(
+        device: HostedDevice,
+        expectedCredential: DeviceCredential?,
+        statusCode: Int,
+    ) {
+        val matchesCredential = expectedCredential == null ||
+            device.deviceId == expectedCredential.deviceId
+        if (!DEVICE_ID.matches(device.deviceId) ||
+            !EDGE_ID.matches(device.edgeId) ||
+            !matchesCredential
+        ) {
+            throw HostedCloudException(statusCode, "INVALID_RESPONSE", "云端设备响应标识不匹配")
+        }
+    }
+
+    private fun throwIfTerminal(call: HostedCallResponse) {
+        if (call.status == "failed" || call.status == "ended") {
+            throw HostedCloudException(200, "CALL_FAILED", "云端呼叫创建失败")
+        }
+    }
+
+    private fun validateSession(session: HostedSessionPayload) {
+        val uri = try {
+            URI(session.livekitUrl)
+        } catch (_: Exception) {
+            null
+        }
+        if (uri?.scheme != "wss" ||
+            uri.host.isNullOrBlank() ||
+            session.token.isBlank() ||
+            session.expiresAt <= clockMs()
+        ) {
+            throw HostedCloudException(200, "INVALID_RESPONSE", "云端会话连接信息不合法")
+        }
+    }
+
+    private fun extractCredential(response: Response): DeviceCredential? {
+        val header = response.headers("Set-Cookie")
+            .firstOrNull { it.startsWith("${GatewayClient.DEVICE_COOKIE}=") } ?: return null
+        val value = header.substringAfter('=').substringBefore(';')
+        val separator = value.indexOf('.')
+        if (separator <= 0 || separator == value.lastIndex) return null
+        return DeviceCredential(value.substring(0, separator), value.substring(separator + 1))
+    }
+}
+
+@Serializable
+data class HostedDevice(
+    val deviceId: String,
+    val edgeId: String,
+    val displayName: String = "",
+)
+
+data class HostedPairResult(
+    val device: HostedDevice,
+    val credential: DeviceCredential,
+) {
+    override fun toString(): String =
+        "HostedPairResult(device=$device, credential=***)"
+}
+
+data class HostedDeviceStatus(
+    val paired: Boolean,
+    val device: HostedDevice?,
+    val edge: JsonObject,
+) {
+    val connected: Boolean
+        get() = edge["connected"]?.jsonPrimitive?.booleanOrNull ?: false
+    val modemOnline: Boolean
+        get() = edge["modemOnline"]?.jsonPrimitive?.booleanOrNull ?: false
+}
+
+data class HostedCallSession(
+    val sessionId: String,
+    val livekitUrl: String,
+    val token: String,
+    val expiresAt: Long,
+) {
+    override fun toString(): String =
+        "HostedCallSession(sessionId=$sessionId, livekitUrl=$livekitUrl, token=***, expiresAt=$expiresAt)"
+}
+
+@Serializable
+private data class HostedCallResponse(
+    val callId: String,
+    val edgeId: String,
+    val status: String,
+    val createdAt: Long,
+    val expiresAt: Long,
+    val session: HostedSessionPayload? = null,
+)
+
+@Serializable
+private data class HostedSessionPayload(
+    val livekitUrl: String,
+    val token: String,
+    val expiresAt: Long,
+)
+
+class HostedCloudException(
+    val statusCode: Int,
+    val errorCode: String,
+    override val message: String,
+) : Exception(message)

--- a/android/app/src/main/kotlin/ai/bondings/callpilot/protocol/Models.kt
+++ b/android/app/src/main/kotlin/ai/bondings/callpilot/protocol/Models.kt
@@ -45,6 +45,8 @@ data class InvitePayload(
 /** 配对凭证：以 `__Host-callpilot-device=<deviceId>.<secret>` Cookie 形式回传网关。 */
 data class DeviceCredential(val deviceId: String, val secret: String) {
     fun asCookieValue(): String = "$deviceId.$secret"
+
+    override fun toString(): String = "DeviceCredential(deviceId=$deviceId, secret=***)"
 }
 
 /**

--- a/android/app/src/main/kotlin/ai/bondings/callpilot/protocol/PairingProtocol.kt
+++ b/android/app/src/main/kotlin/ai/bondings/callpilot/protocol/PairingProtocol.kt
@@ -1,0 +1,55 @@
+package ai.bondings.callpilot.protocol
+
+import okhttp3.OkHttpClient
+
+/** HTTP control protocol selected when the phone was paired. */
+enum class PairingProtocol(val storedValue: String) {
+    TUNNEL("tunnel"),
+    HOSTED("hosted");
+
+    companion object {
+        fun fromStored(value: String?): PairingProtocol =
+            entries.firstOrNull { it.storedValue == value } ?: TUNNEL
+    }
+}
+
+data class NegotiatedPairing(
+    val credential: DeviceCredential,
+    val protocol: PairingProtocol,
+    val edgeId: String? = null,
+)
+
+/** Pair on one origin, preferring hosted v1 and falling back only when that route is absent. */
+class PairingNegotiator(
+    private val baseUrl: String,
+    private val client: OkHttpClient = OkHttpClient(),
+) {
+    fun pair(
+        code: String,
+        displayName: String,
+        preferredProtocol: PairingProtocol? = null,
+    ): NegotiatedPairing = when (preferredProtocol) {
+        PairingProtocol.HOSTED -> pairHosted(code, displayName)
+        PairingProtocol.TUNNEL -> pairTunnel(code, displayName)
+        null -> try {
+            pairHosted(code, displayName)
+        } catch (e: HostedCloudException) {
+            if (e.statusCode != 404 && e.statusCode != 405) throw e
+            pairTunnel(code, displayName)
+        }
+    }
+
+    private fun pairHosted(code: String, displayName: String): NegotiatedPairing {
+        val result = HostedCloudClient(baseUrl, client).claimPairing(code, displayName)
+        return NegotiatedPairing(
+            credential = result.credential,
+            protocol = PairingProtocol.HOSTED,
+            edgeId = result.device.edgeId,
+        )
+    }
+
+    private fun pairTunnel(code: String, displayName: String): NegotiatedPairing {
+        val result = GatewayClient(baseUrl, client).pair(code, displayName)
+        return NegotiatedPairing(result.credential, PairingProtocol.TUNNEL)
+    }
+}

--- a/android/app/src/main/kotlin/ai/bondings/callpilot/ui/DialScreen.kt
+++ b/android/app/src/main/kotlin/ai/bondings/callpilot/ui/DialScreen.kt
@@ -3,8 +3,9 @@ package ai.bondings.callpilot.ui
 import ai.bondings.callpilot.call.CallManager
 import ai.bondings.callpilot.pairing.CredentialStore
 import ai.bondings.callpilot.pairing.StoredPairing
-import ai.bondings.callpilot.protocol.DeviceStatus
 import ai.bondings.callpilot.protocol.GatewayClient
+import ai.bondings.callpilot.protocol.HostedCloudClient
+import ai.bondings.callpilot.protocol.PairingProtocol
 import ai.bondings.callpilot.protocol.Validation
 import android.Manifest
 import android.content.pm.PackageManager
@@ -60,10 +61,7 @@ fun DialScreen(
     onUnpaired: () -> Unit,
 ) {
     val context = LocalContext.current
-    val client = remember(pairing) {
-        GatewayClient(pairing.gatewayUrl).also { it.credential = pairing.credential }
-    }
-    var status by remember { mutableStateOf<DeviceStatus?>(null) }
+    var lineReady by remember { mutableStateOf<Boolean?>(null) }
     var number by remember { mutableStateOf("") }
     var message by remember { mutableStateOf<String?>(null) }
     val scope = rememberCoroutineScope()
@@ -97,10 +95,17 @@ fun DialScreen(
         if (number.removePrefix("+").length < 32) number += key
     }
 
-    LaunchedEffect(client) {
+    LaunchedEffect(pairing) {
         launch(Dispatchers.IO) {
             try {
-                status = client.deviceStatus()
+                lineReady = when (pairing.protocol) {
+                    PairingProtocol.TUNNEL -> GatewayClient(pairing.gatewayUrl)
+                        .also { it.credential = pairing.credential }
+                        .deviceStatus().edgeEnabled
+                    PairingProtocol.HOSTED -> HostedCloudClient(pairing.gatewayUrl)
+                        .also { it.credential = pairing.credential }
+                        .deviceStatus().let { it.connected && it.modemOnline }
+                }
             } catch (e: Exception) {
                 message = "获取线路状态失败：${e.message}"
             }
@@ -125,7 +130,14 @@ fun DialScreen(
                 onClick = {
                     scope.launch(Dispatchers.IO) {
                         try {
-                            client.unpair()
+                            when (pairing.protocol) {
+                                PairingProtocol.TUNNEL -> GatewayClient(pairing.gatewayUrl)
+                                    .also { it.credential = pairing.credential }
+                                    .unpair()
+                                PairingProtocol.HOSTED -> HostedCloudClient(pairing.gatewayUrl)
+                                    .also { it.credential = pairing.credential }
+                                    .unpair()
+                            }
                         } catch (_: Exception) {
                             // 网关不可达时也允许本地解除
                         }
@@ -152,7 +164,7 @@ fun DialScreen(
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                val enabled = status?.edgeEnabled == true
+                val enabled = lineReady == true
                 Box(
                     Modifier
                         .size(10.dp)
@@ -165,7 +177,7 @@ fun DialScreen(
                 Column {
                     Text(
                         when {
-                            status == null -> "线路状态获取中…"
+                            lineReady == null -> "线路状态获取中…"
                             enabled -> "远程拨号已就绪"
                             else -> "远程拨号未启用"
                         },

--- a/android/app/src/main/kotlin/ai/bondings/callpilot/ui/PairScreen.kt
+++ b/android/app/src/main/kotlin/ai/bondings/callpilot/ui/PairScreen.kt
@@ -2,8 +2,9 @@ package ai.bondings.callpilot.ui
 
 import ai.bondings.callpilot.pairing.CredentialStore
 import ai.bondings.callpilot.pairing.StoredPairing
-import ai.bondings.callpilot.protocol.GatewayClient
 import ai.bondings.callpilot.protocol.PairingLink
+import ai.bondings.callpilot.protocol.PairingNegotiator
+import ai.bondings.callpilot.protocol.PairingProtocol
 import android.os.Build
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -25,6 +26,9 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -50,6 +54,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun PairScreen(store: CredentialStore, onPaired: (StoredPairing) -> Unit) {
     var gatewayBase by remember { mutableStateOf(store.loadLastGateway()) }
+    var protocol by remember { mutableStateOf<PairingProtocol?>(null) }
     var code by remember { mutableStateOf("") }
     var deviceName by remember { mutableStateOf(Build.MODEL ?: "Android") }
     var busy by remember { mutableStateOf(false) }
@@ -61,7 +66,10 @@ fun PairScreen(store: CredentialStore, onPaired: (StoredPairing) -> Unit) {
     fun applyParsed(text: String): Boolean {
         val parsed = PairingLink.parse(text)
         if (parsed.isEmpty) return false
-        parsed.gatewayBase?.let { gatewayBase = it }
+        parsed.gatewayBase?.let {
+            gatewayBase = it
+            protocol = null
+        }
         parsed.code?.let { code = it }
         error = null
         return true
@@ -154,6 +162,23 @@ fun PairScreen(store: CredentialStore, onPaired: (StoredPairing) -> Unit) {
         )
 
         Spacer(Modifier.height(18.dp))
+        SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+            val options: List<Pair<PairingProtocol?, String>> = listOf(
+                null to "自动",
+                PairingProtocol.HOSTED to "云托管",
+                PairingProtocol.TUNNEL to "Tunnel",
+            )
+            options.forEachIndexed { index, (value, label) ->
+                SegmentedButton(
+                    selected = protocol == value,
+                    onClick = { protocol = value },
+                    shape = SegmentedButtonDefaults.itemShape(index, options.size),
+                    label = { Text(label) },
+                )
+            }
+        }
+
+        Spacer(Modifier.height(18.dp))
         OutlinedTextField(
             value = deviceName,
             onValueChange = { deviceName = it },
@@ -178,9 +203,20 @@ fun PairScreen(store: CredentialStore, onPaired: (StoredPairing) -> Unit) {
                 busy = true
                 scope.launch(Dispatchers.IO) {
                     try {
-                        val client = GatewayClient(base)
-                        val result = client.pair(PairingLink.formatCode(code), deviceName.trim())
-                        val pairing = StoredPairing(base, deviceName.trim(), result.credential)
+                        val name = deviceName.trim()
+                        val formattedCode = PairingLink.formatCode(code)
+                        val result = PairingNegotiator(base).pair(
+                            formattedCode,
+                            name,
+                            preferredProtocol = protocol,
+                        )
+                        val pairing = StoredPairing(
+                            gatewayUrl = base,
+                            displayName = name,
+                            credential = result.credential,
+                            protocol = result.protocol,
+                            edgeId = result.edgeId,
+                        )
                         store.save(pairing)
                         onPaired(pairing)
                     } catch (e: Exception) {

--- a/android/app/src/test/kotlin/ai/bondings/callpilot/call/CallManagerTest.kt
+++ b/android/app/src/test/kotlin/ai/bondings/callpilot/call/CallManagerTest.kt
@@ -4,9 +4,13 @@ import ai.bondings.callpilot.media.RemoteSession
 import ai.bondings.callpilot.media.SessionEvent
 import ai.bondings.callpilot.pairing.StoredPairing
 import ai.bondings.callpilot.protocol.DeviceCredential
+import ai.bondings.callpilot.protocol.HostedCallSession
+import ai.bondings.callpilot.protocol.HostedCloudException
 import ai.bondings.callpilot.protocol.Invite
+import ai.bondings.callpilot.protocol.PairingProtocol
 import ai.bondings.callpilot.protocol.Signaling
 import java.util.Base64
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
@@ -17,6 +21,7 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -34,6 +39,10 @@ class CallManagerTest {
         }
 
         override suspend fun sendCommand(json: String) {
+            if (json.contains("\"dial\"")) {
+                dialStarted.complete(Unit)
+                dialRelease?.await()
+            }
             commands += json
         }
 
@@ -42,6 +51,9 @@ class CallManagerTest {
         override fun disconnect() {
             disconnected = true
         }
+
+        val dialStarted = CompletableDeferred<Unit>()
+        var dialRelease: CompletableDeferred<Unit>? = null
 
         suspend fun emit(event: SessionEvent) = _events.emit(event)
     }
@@ -78,10 +90,16 @@ class CallManagerTest {
 
         fun manager(
             session: RemoteSession,
-            inviteProvider: (StoredPairing) -> Invite,
+            hostedSessionProvider: suspend (StoredPairing, String) -> HostedCallSession = { _, _ ->
+                error("hosted provider should not be called")
+            },
+            idempotencyKeyProvider: () -> String = { "android-test-idempotency" },
+            inviteProvider: suspend (StoredPairing) -> Invite,
         ): CallManager = CallManager(
             sessionFactory = { session },
             inviteProvider = inviteProvider,
+            hostedSessionProvider = hostedSessionProvider,
+            idempotencyKeyProvider = idempotencyKeyProvider,
             onForeground = { foreground += it },
             scope = scope,
             ioDispatcher = dispatcher,
@@ -245,6 +263,153 @@ class CallManagerTest {
         advanceUntilIdle()
         assertEquals(1, invites)
         assertEquals(CallState.WaitingMedia("10000"), manager.state.value)
+        h.close()
+    }
+
+    @Test
+    fun `hosted 配对选择 v1 provider 而不是 Tunnel provider`() = runTest {
+        val h = Harness(this)
+        val session = FakeSession()
+        var tunnelCalls = 0
+        var hostedCalls = 0
+        val manager = h.manager(
+            session = session,
+            inviteProvider = { tunnelCalls++; invite() },
+            hostedSessionProvider = { _, key ->
+                hostedCalls++
+                assertEquals("android-test-idempotency", key)
+                HostedCallSession(
+                    sessionId = "call_abcdefghijkl",
+                    livekitUrl = "wss://lk.example.com",
+                    token = "tok",
+                    expiresAt = 9999,
+                )
+            },
+        )
+        val hostedPairing = pairing.copy(
+            protocol = PairingProtocol.HOSTED,
+            edgeId = "edge_abcdefghijkl",
+        )
+
+        manager.startCall(hostedPairing, "10000")
+        advanceUntilIdle()
+
+        assertEquals(0, tunnelCalls)
+        assertEquals(1, hostedCalls)
+        assertTrue(session.connected)
+        assertEquals(CallState.WaitingMedia("10000"), manager.state.value)
+        h.close()
+    }
+
+    @Test
+    fun `Tunnel 配对继续选择 v0 provider`() = runTest {
+        val h = Harness(this)
+        val session = FakeSession()
+        var tunnelCalls = 0
+        var hostedCalls = 0
+        val manager = h.manager(
+            session = session,
+            inviteProvider = {
+                tunnelCalls++
+                invite()
+            },
+            hostedSessionProvider = { _, _ ->
+                hostedCalls++
+                error("hosted provider should not be called")
+            },
+        )
+
+        manager.startCall(pairing, "10000")
+        advanceUntilIdle()
+
+        assertEquals(1, tunnelCalls)
+        assertEquals(0, hostedCalls)
+        assertTrue(session.connected)
+        assertEquals(CallState.WaitingMedia("10000"), manager.state.value)
+        h.close()
+    }
+
+    @Test
+    fun `hosted 会话轮询中挂断不会在轮询完成后复活通话`() = runTest {
+        val h = Harness(this)
+        val session = FakeSession()
+        val sessionResult = CompletableDeferred<HostedCallSession>()
+        val manager = h.manager(
+            session = session,
+            inviteProvider = { error("Tunnel provider should not be called") },
+            hostedSessionProvider = { _, _ -> sessionResult.await() },
+        )
+        val hostedPairing = pairing.copy(
+            protocol = PairingProtocol.HOSTED,
+            edgeId = "edge_abcdefghijkl",
+        )
+
+        manager.startCall(hostedPairing, "10000")
+        advanceUntilIdle()
+        assertEquals(CallState.Preparing("10000"), manager.state.value)
+
+        manager.hangup()
+        advanceUntilIdle()
+        sessionResult.complete(
+            HostedCallSession(
+                sessionId = "call_abcdefghijkl",
+                livekitUrl = "wss://lk.example.com",
+                token = "tok",
+                expiresAt = 9999,
+            )
+        )
+        advanceUntilIdle()
+
+        assertEquals(CallState.Ended("10000", "local_hangup"), manager.state.value)
+        assertFalse(session.connected)
+        h.close()
+    }
+
+    @Test
+    fun `挂断与 media_ready 交错时绝不发送 dial`() = runTest {
+        val h = Harness(this)
+        val session = FakeSession().also {
+            it.dialRelease = CompletableDeferred()
+        }
+        val manager = h.manager(session) { invite() }
+
+        manager.startCall(pairing, "10000")
+        advanceUntilIdle()
+        session.emit(SessionEvent.Edge(Signaling.Event.Status("media_ready")))
+        advanceUntilIdle()
+        assertTrue(session.dialStarted.isCompleted)
+
+        manager.hangup()
+        session.dialRelease?.complete(Unit)
+        advanceUntilIdle()
+
+        assertFalse(session.commands.any { it.contains("\"dial\"") })
+        assertEquals(CallState.Ended("10000", "local_hangup"), manager.state.value)
+        h.close()
+    }
+
+    @Test
+    fun `hosted 业务错误透传稳定 code`() = runTest {
+        val h = Harness(this)
+        val manager = h.manager(
+            session = FakeSession(),
+            inviteProvider = { error("Tunnel provider should not be called") },
+            hostedSessionProvider = { _, _ ->
+                throw HostedCloudException(409, "LINE_BUSY", "Line is busy")
+            },
+        )
+        val hostedPairing = pairing.copy(
+            protocol = PairingProtocol.HOSTED,
+            edgeId = "edge_abcdefghijkl",
+        )
+
+        manager.startCall(hostedPairing, "10000")
+        advanceUntilIdle()
+
+        assertEquals(
+            CallState.Failed("10000", "Line is busy", code = "LINE_BUSY"),
+            manager.state.value,
+        )
         h.close()
     }
 }

--- a/android/app/src/test/kotlin/ai/bondings/callpilot/protocol/CredentialRedactionTest.kt
+++ b/android/app/src/test/kotlin/ai/bondings/callpilot/protocol/CredentialRedactionTest.kt
@@ -1,0 +1,39 @@
+package ai.bondings.callpilot.protocol
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CredentialRedactionTest {
+    @Test
+    fun `DeviceCredential toString 不包含 secret`() {
+        val text = DeviceCredential("device_abcdefghijkl", "secret-plaintext").toString()
+
+        assertTrue(text.contains("device_abcdefghijkl"))
+        assertFalse(text.contains("secret-plaintext"))
+    }
+
+    @Test
+    fun `HostedPairResult toString 不包含 secret`() {
+        val result = HostedPairResult(
+            device = HostedDevice("device_abcdefghijkl", "edge_abcdefghijkl"),
+            credential = DeviceCredential("device_abcdefghijkl", "secret-plaintext"),
+        )
+
+        assertTrue(result.toString().contains("device_abcdefghijkl"))
+        assertFalse(result.toString().contains("secret-plaintext"))
+    }
+
+    @Test
+    fun `HostedCallSession toString 不包含 token`() {
+        val session = HostedCallSession(
+            sessionId = "call_abcdefghijkl",
+            livekitUrl = "wss://lk.example.com",
+            token = "jwt-plaintext",
+            expiresAt = 9999,
+        )
+
+        assertTrue(session.toString().contains("call_abcdefghijkl"))
+        assertFalse(session.toString().contains("jwt-plaintext"))
+    }
+}

--- a/android/app/src/test/kotlin/ai/bondings/callpilot/protocol/HostedCloudClientTest.kt
+++ b/android/app/src/test/kotlin/ai/bondings/callpilot/protocol/HostedCloudClientTest.kt
@@ -1,0 +1,374 @@
+package ai.bondings.callpilot.protocol
+
+import java.io.IOException
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okio.Buffer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class HostedCloudClientTest {
+    private lateinit var server: MockWebServer
+    private lateinit var client: HostedCloudClient
+    private var nowMs = 1_000L
+    private val sleeps = mutableListOf<Long>()
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        client = HostedCloudClient(
+            baseUrl = server.url("/").toString(),
+            clockMs = { nowMs },
+            sleepMs = { delay ->
+                sleeps += delay
+                nowMs += delay
+            },
+        )
+    }
+
+    @After
+    fun tearDown() = server.shutdown()
+
+    private fun expectedOrigin(): String = "http://${server.hostName}:${server.port}"
+
+    @Test
+    fun `claimPairing 使用 camelCase 并提取云凭证`() {
+        server.enqueue(
+            MockResponse().setResponseCode(201)
+                .addHeader(
+                    "Set-Cookie",
+                    "__Host-callpilot-device=device_abcdefghijkl.secret-value; Path=/; Secure; HttpOnly",
+                )
+                .setBody(
+                    """{"paired":true,"device":{"deviceId":"device_abcdefghijkl","edgeId":"edge_abcdefghijkl","displayName":"Pixel"}}"""
+                ),
+        )
+
+        val result = client.claimPairing("ABCD-EFGH", "Pixel")
+
+        assertEquals("edge_abcdefghijkl", result.device.edgeId)
+        assertEquals(DeviceCredential("device_abcdefghijkl", "secret-value"), result.credential)
+        val request = server.takeRequest()
+        assertEquals("/v1/pairing-sessions/claim", request.path)
+        assertEquals(expectedOrigin(), request.getHeader("Origin"))
+        assertTrue(request.body.readUtf8().contains("\"displayName\":\"Pixel\""))
+    }
+
+    @Test
+    fun `claimPairing 拒绝与 device 不匹配的 Cookie 凭证`() {
+        server.enqueue(
+            MockResponse().setResponseCode(201)
+                .addHeader(
+                    "Set-Cookie",
+                    "__Host-callpilot-device=device_otherresponse.secret-value; Path=/; Secure",
+                )
+                .setBody(
+                    """{"paired":true,"device":{"deviceId":"device_abcdefghijkl","edgeId":"edge_abcdefghijkl","displayName":"Pixel"}}"""
+                ),
+        )
+
+        val error = assertThrows(HostedCloudException::class.java) {
+            client.claimPairing("ABCD-EFGH", "Pixel")
+        }
+
+        assertEquals("INVALID_RESPONSE", error.errorCode)
+        assertEquals(null, client.credential)
+    }
+
+    @Test
+    fun `createSession 创建呼叫并轮询到 ready`() {
+        client.credential = DeviceCredential("device_abcdefghijkl", "secret-value")
+        server.enqueue(
+            MockResponse().setResponseCode(202).setBody(
+                """{"callId":"call_abcdefghijkl","edgeId":"edge_abcdefghijkl","status":"pending","createdAt":1,"expiresAt":9999}"""
+            ),
+        )
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """{"callId":"call_abcdefghijkl","edgeId":"edge_abcdefghijkl","status":"pending","createdAt":1,"expiresAt":9999}"""
+            ),
+        )
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """{"callId":"call_abcdefghijkl","edgeId":"edge_abcdefghijkl","status":"ready","createdAt":1,"expiresAt":9999,"session":{"livekitUrl":"wss://lk.example.com","token":"jwt-token","expiresAt":9999}}"""
+            ),
+        )
+
+        val session = client.createSession("edge_abcdefghijkl", "android-1234567890")
+
+        assertEquals("call_abcdefghijkl", session.sessionId)
+        assertEquals("wss://lk.example.com", session.livekitUrl)
+        assertEquals("jwt-token", session.token)
+        val create = server.takeRequest()
+        assertEquals("/v1/calls", create.path)
+        assertEquals(
+            "__Host-callpilot-device=device_abcdefghijkl.secret-value",
+            create.getHeader("Cookie"),
+        )
+        val body = create.body.readUtf8()
+        assertTrue(body.contains("\"edgeId\":\"edge_abcdefghijkl\""))
+        assertTrue(body.contains("\"idempotencyKey\":\"android-1234567890\""))
+        assertEquals("/v1/calls/call_abcdefghijkl", server.takeRequest().path)
+        assertEquals("/v1/calls/call_abcdefghijkl", server.takeRequest().path)
+    }
+
+    @Test
+    fun `failed 呼叫停止轮询`() {
+        client.credential = DeviceCredential("device_abcdefghijkl", "secret-value")
+        server.enqueue(
+            MockResponse().setResponseCode(202).setBody(
+                """{"callId":"call_abcdefghijkl","edgeId":"edge_abcdefghijkl","status":"pending","createdAt":1,"expiresAt":9999}"""
+            ),
+        )
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """{"callId":"call_abcdefghijkl","edgeId":"edge_abcdefghijkl","status":"failed","createdAt":1,"expiresAt":9999}"""
+            ),
+        )
+        val error = assertThrows(HostedCloudException::class.java) {
+            client.createSession("edge_abcdefghijkl", "android-1234567890")
+        }
+        assertEquals("CALL_FAILED", error.errorCode)
+    }
+
+    @Test
+    fun `创建响应已经 failed 时不再轮询`() {
+        client.credential = DeviceCredential("device_abcdefghijkl", "secret-value")
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """{"callId":"call_abcdefghijkl","edgeId":"edge_abcdefghijkl","status":"failed","createdAt":1,"expiresAt":9999}"""
+            ),
+        )
+        repeat(4) {
+            server.enqueue(
+                MockResponse().setResponseCode(200).setBody(
+                    """{"callId":"call_abcdefghijkl","edgeId":"edge_abcdefghijkl","status":"pending","createdAt":1,"expiresAt":9999}"""
+                ),
+            )
+        }
+
+        val error = assertThrows(HostedCloudException::class.java) {
+            client.createSession("edge_abcdefghijkl", "android-1234567890")
+        }
+
+        assertEquals("CALL_FAILED", error.errorCode)
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun `轮询响应的 callId 或 edgeId 不匹配时拒绝会话`() {
+        client.credential = DeviceCredential("device_abcdefghijkl", "secret-value")
+        server.enqueue(
+            MockResponse().setResponseCode(202).setBody(
+                """{"callId":"call_abcdefghijkl","edgeId":"edge_abcdefghijkl","status":"pending","createdAt":1,"expiresAt":9999}"""
+            ),
+        )
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """{"callId":"call_otherresponse","edgeId":"edge_abcdefghijkl","status":"ready","createdAt":1,"expiresAt":9999,"session":{"livekitUrl":"wss://lk.example.com","token":"jwt-token","expiresAt":9999}}"""
+            ),
+        )
+
+        val error = assertThrows(HostedCloudException::class.java) {
+            client.createSession("edge_abcdefghijkl", "android-1234567890")
+        }
+
+        assertEquals("INVALID_RESPONSE", error.errorCode)
+    }
+
+    @Test
+    fun `ready 会话必须提供 wss 地址和非空 token`() {
+        client.credential = DeviceCredential("device_abcdefghijkl", "secret-value")
+        server.enqueue(
+            MockResponse().setResponseCode(202).setBody(
+                """{"callId":"call_abcdefghijkl","edgeId":"edge_abcdefghijkl","status":"pending","createdAt":1,"expiresAt":9999}"""
+            ),
+        )
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """{"callId":"call_abcdefghijkl","edgeId":"edge_abcdefghijkl","status":"ready","createdAt":1,"expiresAt":9999,"session":{"livekitUrl":"https://lk.example.com","token":"","expiresAt":9999}}"""
+            ),
+        )
+
+        val error = assertThrows(HostedCloudException::class.java) {
+            client.createSession("edge_abcdefghijkl", "android-1234567890")
+        }
+
+        assertEquals("INVALID_RESPONSE", error.errorCode)
+    }
+
+    @Test
+    fun `ready 会话凭证已过期时拒绝 payload`() {
+        client.credential = DeviceCredential("device_abcdefghijkl", "secret-value")
+        server.enqueue(
+            MockResponse().setResponseCode(202).setBody(
+                """{"callId":"call_abcdefghijkl","edgeId":"edge_abcdefghijkl","status":"pending","createdAt":1,"expiresAt":9999}"""
+            ),
+        )
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """{"callId":"call_abcdefghijkl","edgeId":"edge_abcdefghijkl","status":"ready","createdAt":1,"expiresAt":9999,"session":{"livekitUrl":"wss://lk.example.com","token":"jwt-token","expiresAt":999}}"""
+            ),
+        )
+
+        val error = assertThrows(HostedCloudException::class.java) {
+            client.createSession("edge_abcdefghijkl", "android-1234567890")
+        }
+
+        assertEquals("INVALID_RESPONSE", error.errorCode)
+    }
+
+    @Test
+    fun `结构化 API 错误按 code 暴露`() {
+        server.enqueue(
+            MockResponse().setResponseCode(409).setBody(
+                """{"error":{"code":"EDGE_OFFLINE","message":"Edge is offline","requestId":"req_1"}}"""
+            ),
+        )
+
+        val error = assertThrows(HostedCloudException::class.java) {
+            client.createSession("edge_abcdefghijkl", "android-1234567890")
+        }
+        assertEquals(409, error.statusCode)
+        assertEquals("EDGE_OFFLINE", error.errorCode)
+        assertEquals("Edge is offline", error.message)
+    }
+
+    @Test
+    fun `deviceStatus 与 unpair 都携带设备 Cookie`() {
+        client.credential = DeviceCredential("device_abcdefghijkl", "secret-value")
+        server.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """{"ok":true,"paired":true,"device":{"deviceId":"device_abcdefghijkl","edgeId":"edge_abcdefghijkl","displayName":"Pixel"},"edge":{"connected":true,"modemOnline":true,"lineBusy":false}}"""
+            ),
+        )
+        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"paired":false}"""))
+
+        val status = client.deviceStatus()
+        assertTrue(status.connected)
+        assertTrue(status.modemOnline)
+        client.unpair()
+
+        val get = server.takeRequest()
+        assertEquals("GET", get.method)
+        assertEquals("/v1/device", get.path)
+        assertTrue(get.getHeader("Cookie")!!.startsWith("__Host-callpilot-device="))
+        val delete = server.takeRequest()
+        assertEquals("DELETE", delete.method)
+        assertEquals(expectedOrigin(), delete.getHeader("Origin"))
+        assertEquals(null, client.credential)
+    }
+
+    @Test
+    fun `轮询到服务端 deadline 返回超时`() {
+        nowMs = 1_000
+        client = HostedCloudClient(
+            baseUrl = server.url("/").toString(),
+            clockMs = { nowMs },
+            sleepMs = { nowMs += it },
+        ).also {
+            it.credential = DeviceCredential("device_abcdefghijkl", "secret-value")
+        }
+        repeat(3) { index ->
+            server.enqueue(
+                MockResponse().setResponseCode(if (index == 0) 202 else 200).setBody(
+                    """{"callId":"call_abcdefghijkl","edgeId":"edge_abcdefghijkl","status":"pending","createdAt":1,"expiresAt":1500}"""
+                ),
+            )
+        }
+
+        val error = assertThrows(HostedCloudException::class.java) {
+            client.createSession("edge_abcdefghijkl", "android-1234567890")
+        }
+        assertEquals("SESSION_TIMEOUT", error.errorCode)
+    }
+
+    @Test
+    fun `轮询以服务端毫秒 expiresAt 为 deadline 且三秒后降频`() {
+        nowMs = 0
+        sleeps.clear()
+        client = HostedCloudClient(
+            baseUrl = server.url("/").toString(),
+            clockMs = { nowMs },
+            sleepMs = { delay ->
+                sleeps += delay
+                nowMs += delay
+            },
+        ).also {
+            it.credential = DeviceCredential("device_abcdefghijkl", "secret-value")
+        }
+        repeat(15) { index ->
+            server.enqueue(
+                MockResponse().setResponseCode(if (index == 0) 202 else 200).setBody(
+                    """{"callId":"call_abcdefghijkl","edgeId":"edge_abcdefghijkl","status":"pending","createdAt":0,"expiresAt":5000}"""
+                ),
+            )
+        }
+
+        val error = assertThrows(HostedCloudException::class.java) {
+            client.createSession("edge_abcdefghijkl", "android-1234567890")
+        }
+
+        assertEquals("SESSION_TIMEOUT", error.errorCode)
+        assertEquals(List(12) { 250L } + listOf(1_000L, 1_000L), sleeps)
+        assertEquals(5_000L, nowMs)
+    }
+
+    @Test
+    fun `POST 传输失败只用同一 idempotencyKey 重试一次`() {
+        // 全程 interceptor 合成响应、不真开 socket：MockWebServer + 关闭
+        // retryOnConnectionFailure 的组合会禁用 OkHttp 路由回退，在 localhost
+        // 双栈（::1/127.0.0.1）环境下产生与被测逻辑无关的 ConnectException。
+        nowMs = 1_000
+        val postBodies = mutableListOf<String>()
+        val pendingBody =
+            """{"callId":"call_abcdefghijkl","edgeId":"edge_abcdefghijkl","status":"pending","createdAt":1,"expiresAt":9999}"""
+        val readyBody =
+            """{"callId":"call_abcdefghijkl","edgeId":"edge_abcdefghijkl","status":"ready","createdAt":1,"expiresAt":9999,"session":{"livekitUrl":"wss://lk.example.com","token":"jwt-token","expiresAt":9999}}"""
+        client = HostedCloudClient(
+            baseUrl = "https://cloud.example.test/",
+            client = OkHttpClient.Builder()
+                .addInterceptor { chain ->
+                    val request = chain.request()
+                    val body = if (request.method == "POST") {
+                        val buffer = Buffer()
+                        request.body?.writeTo(buffer)
+                        postBodies += buffer.readUtf8()
+                        if (postBodies.size == 1) throw IOException("simulated transport failure")
+                        pendingBody
+                    } else {
+                        readyBody
+                    }
+                    Response.Builder()
+                        .request(request)
+                        .protocol(Protocol.HTTP_1_1)
+                        .code(if (request.method == "POST") 202 else 200)
+                        .message("OK")
+                        .body(body.toResponseBody("application/json".toMediaType()))
+                        .build()
+                }
+                .build(),
+            clockMs = { nowMs },
+            sleepMs = { nowMs += it },
+        ).also {
+            it.credential = DeviceCredential("device_abcdefghijkl", "secret-value")
+        }
+
+        val result = client.createSession("edge_abcdefghijkl", "android-stable-key1")
+
+        assertEquals(2, postBodies.size)
+        assertEquals(postBodies[0], postBodies[1])
+        assertTrue(postBodies[1].contains("android-stable-key1"))
+        assertEquals("jwt-token", result.token)
+    }
+}

--- a/android/app/src/test/kotlin/ai/bondings/callpilot/protocol/PairingLinkTest.kt
+++ b/android/app/src/test/kotlin/ai/bondings/callpilot/protocol/PairingLinkTest.kt
@@ -15,6 +15,13 @@ class PairingLinkTest {
     }
 
     @Test
+    fun `hosted 根路径配对链接只解析同源信息不猜协议`() {
+        val p = PairingLink.parse("https://dial.bondings.ai/#pair=ABCD-EFGH")
+        assertEquals("https://dial.bondings.ai", p.gatewayBase)
+        assertEquals("ABCDEFGH", p.code)
+    }
+
+    @Test
     fun `带端口的网关保留端口`() {
         val p = PairingLink.parse("https://dial.example.com:8443/x.html#pair=AAAA-BBBB")
         assertEquals("https://dial.example.com:8443", p.gatewayBase)
@@ -51,5 +58,11 @@ class PairingLinkTest {
         assertEquals("AB12CD34", PairingLink.normalizeCode(" ab12-cd34 ".trim()))
         assertNull(PairingLink.normalizeCode("ABC"))
         assertEquals("AB12-CD34", PairingLink.formatCode("AB12CD34"))
+    }
+
+    @Test
+    fun `旧存储缺少协议字段时默认 Tunnel`() {
+        assertEquals(PairingProtocol.TUNNEL, PairingProtocol.fromStored(null))
+        assertEquals(PairingProtocol.TUNNEL, PairingProtocol.fromStored("future"))
     }
 }

--- a/android/app/src/test/kotlin/ai/bondings/callpilot/protocol/PairingNegotiatorTest.kt
+++ b/android/app/src/test/kotlin/ai/bondings/callpilot/protocol/PairingNegotiatorTest.kt
@@ -1,0 +1,102 @@
+package ai.bondings.callpilot.protocol
+
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Before
+import org.junit.Test
+
+class PairingNegotiatorTest {
+    private lateinit var server: MockWebServer
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+    }
+
+    @After
+    fun tearDown() = server.shutdown()
+
+    @Test
+    fun `自动协商在 v1 路由 404 时回退同源 Tunnel`() {
+        server.enqueue(MockResponse().setResponseCode(404).setBody("Not found"))
+        server.enqueue(
+            MockResponse().setResponseCode(200)
+                .addHeader(
+                    "Set-Cookie",
+                    "__Host-callpilot-device=dev123.secret456; Path=/; Secure",
+                )
+                .setBody(
+                    """{"ok":true,"paired":true,"device":{"device_id":"dev123","display_name":"Pixel"}}"""
+                ),
+        )
+
+        val result = PairingNegotiator(server.url("/").toString()).pair("ABCD-EFGH", "Pixel")
+
+        assertEquals(PairingProtocol.TUNNEL, result.protocol)
+        assertEquals("/v1/pairing-sessions/claim", server.takeRequest().path)
+        assertEquals("/api/pair", server.takeRequest().path)
+    }
+
+    @Test
+    fun `自动协商 hosted 成功时不访问 Tunnel`() {
+        server.enqueue(
+            MockResponse().setResponseCode(201)
+                .addHeader(
+                    "Set-Cookie",
+                    "__Host-callpilot-device=device_abcdefghijkl.secret-value; Path=/; Secure",
+                )
+                .setBody(
+                    """{"paired":true,"device":{"deviceId":"device_abcdefghijkl","edgeId":"edge_abcdefghijkl","displayName":"Pixel"}}"""
+                ),
+        )
+
+        val result = PairingNegotiator(server.url("/").toString()).pair("ABCD-EFGH", "Pixel")
+
+        assertEquals(PairingProtocol.HOSTED, result.protocol)
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun `v1 业务错误不回退 Tunnel`() {
+        server.enqueue(
+            MockResponse().setResponseCode(401).setBody(
+                """{"error":{"code":"INVALID_PAIRING","message":"expired","requestId":"req_1"}}"""
+            ),
+        )
+
+        val error = assertThrows(HostedCloudException::class.java) {
+            PairingNegotiator(server.url("/").toString()).pair("ABCD-EFGH", "Pixel")
+        }
+
+        assertEquals("INVALID_PAIRING", error.errorCode)
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun `手动选择 Tunnel 时直接使用 v0`() {
+        server.enqueue(
+            MockResponse().setResponseCode(200)
+                .addHeader(
+                    "Set-Cookie",
+                    "__Host-callpilot-device=dev123.secret456; Path=/; Secure",
+                )
+                .setBody(
+                    """{"ok":true,"paired":true,"device":{"device_id":"dev123","display_name":"Pixel"}}"""
+                ),
+        )
+
+        val result = PairingNegotiator(server.url("/").toString()).pair(
+            "ABCD-EFGH",
+            "Pixel",
+            preferredProtocol = PairingProtocol.TUNNEL,
+        )
+
+        assertEquals(PairingProtocol.TUNNEL, result.protocol)
+        assertEquals("/api/pair", server.takeRequest().path)
+        assertEquals(1, server.requestCount)
+    }
+}

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -117,3 +117,23 @@ EncryptedSharedPreferences），后续鉴权接口同理。
 3. `/api/session` 响应直接返回结构化 `{livekit_url, token, session_id, expires_at}`
    字段（原生免解 fragment；fragment 形式保留给 web）；
 4. `remote_dialer_status()` 的字段清单文档化（App 首页线路状态依赖它）。
+
+## 五、Hosted 云控制面 `/v1`
+
+当 Edge 启用 `REMOTE_CLOUD_ENABLED=true` 时，Android App 按配对来源改走 hosted
+adapter；原有 Tunnel `/api/*` adapter 与已保存凭证保持不变。Hosted 的完整契约以
+[`remote-cloud-protocol.md`](remote-cloud-protocol.md) 为 SSOT，本文只记录原生端差异：
+
+- `POST /v1/pairing-sessions/claim` 使用 camelCase 请求字段，并从
+  `__Host-callpilot-device` 的 `Set-Cookie` 响应中提取长期设备凭证；原生端后续手动发送
+  同名 `Cookie` 与控制面 origin 对应的 `Origin`。
+- 配对结果额外保存 `edgeId` 和协议标记 `hosted`；未包含协议标记的旧存储数据一律按
+  `tunnel` 读取，避免升级后丢失已有配对。
+- `POST /v1/calls` 携带 `edgeId` 与每次呼叫唯一的 `idempotencyKey`，随后轮询
+  `GET /v1/calls/{callId}`；仅在响应的 `session` 中取得结构化 `livekitUrl`、`token`
+  和 `expiresAt` 后连接 LiveKit，不解析 URL fragment。
+- LiveKit 的 `callpilot.control` / `callpilot.status` topic 和 `media_ready` 后才发送
+  `dial` 的门控语义与 Tunnel 共用，不因控制面协议改变。
+- Hosted 与 Tunnel 配对链接都可能使用根路径，App 不按 URL 形态猜协议。自动模式先向同一
+  origin 提交 hosted claim；仅当 `/v1/pairing-sessions/claim` 返回 404/405 时回退
+  `/api/pair`。业务错误不回退，避免重复提交已被服务端处理的配对码；界面仍保留显式协议选择兜底。

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -1,7 +1,7 @@
 # 远程拨号协议契约（Edge ↔ 远程客户端）
 
-Web Dialer（#31）与 Android App（#36）共同遵守的协议描述。**基线：`feat/issue-31-web-dialer`
-@ `8003677`**；该分支仍在演进，协议变动以 codex 确认为准，变动后同步更新本文档。
+Web Dialer（#31）与 Android App（#36）共同遵守的协议描述。**基线：已合入 `main`（#33）**；
+其后 #39/#40 仅为客户端缓存/交付修复，无协议变更。协议如有变动，确认后同步更新本文档。
 
 ## 总体架构
 
@@ -30,11 +30,20 @@ AgentCall Edge ──AT/PCM── EC20 Dongle ──PSTN── 对端
 设备/线路状态。凭 Cookie 鉴别是否已配对：
 
 ```jsonc
-// 未配对
+// 未配对（网关瘦身响应，只含两个布尔）
 {"ok": true, "paired": false, "edge": {"enabled": bool, "configured": bool}}
-// 已配对
-{"ok": true, "paired": true, "device": {...}, "edge": {/* remote_dialer_status() 全量 */}}
+// 已配对：edge = remote_dialer_status() 全量
+{"ok": true, "paired": true, "device": {...}, "edge": {
+  "enabled": bool, "cloud_enabled": bool, "configured": bool,
+  "missing": ["缺失的必需配置键"], "active": bool,
+  // ↓ coordinator 附加字段：仅在存在远程会话 worker 时出现，无 worker 时整组消失
+  "session_id": "...", "edge_ready": bool, "browser_connected": bool,
+  "media_ready": bool, "call_active": bool, "expires_at": 1234567890.0,
+  "status": "<最近一次 status 事件值，初始 starting>"
+}}
 ```
+
+`browser_connected` 为当前兼容命名——原生客户端同样以此字段判媒体端连接（#37 结论）。
 
 ### POST `/api/pair`　`{"code": "XXXX-XXXX", "display_name": "..."}`
 
@@ -80,12 +89,15 @@ EncryptedSharedPreferences），后续鉴权接口同理。
 | topic | 方向 | 消息 |
 |---|---|---|
 | `callpilot.control` | 客户端 → Edge | `{"type":"dial","number":"...","idempotency_key":"..."}`；`{"type":"hangup"}`；`{"type":"dtmf","digits":"..."}` |
-| `callpilot.status` | Edge → 客户端 | `{"type":"status","status":"<字符串>"}`；`{"type":"remote_call","status":"dialing"\|"connected"\|...}` |
+| `callpilot.status` | Edge → 客户端 | `{"type":"status","status":"<字符串>"}`（如 `media_ready`/`dialing`/`connected`/`ended`/`failed`，可带 `reason`/`code`） |
 
 - 号码格式：`\+?[0-9*#]{1,32}`；DTMF：`[0-9*#]{1,16}`。
 - 控制包经 topic、发送者身份、大小、schema、状态五重校验；重复 `dial`（同 idempotency
   key）不重复 ATD。
-- 身份命名：浏览器 `web-*`、Edge `edge-*`（原生拟用 `app-*`，待 #31 确认）。
+- `type=remote_call` 是 Edge 本地 EventHub/审计事件，**不经 data channel 下发**（#37 裁决），
+  客户端只需消费 `type=status`。
+- 身份命名：浏览器 `web-*`、Edge `edge-*`；`app-*` 原生身份类别按 #37 审计结论 **defer**
+  （原生沿用 `web-*` 兼容身份，暂不新增类别）。
 
 ## 三、媒体与安全语义
 
@@ -113,10 +125,10 @@ EncryptedSharedPreferences），后续鉴权接口同理。
 **提请 #31 侧评估的需求**（记录于对应 issue，非阻塞）：
 
 1. 支持 `Authorization: Bearer <device_id>.<secret>` 作为 Cookie 的等价鉴权（原生更自然）；
-2. 预留/允许 `app-*` 身份类别，审计可区分 web 与原生；
+2. 预留/允许 `app-*` 身份类别，审计可区分 web 与原生（按 #37 审计结论 **defer**，见 §二）；
 3. `/api/session` 响应直接返回结构化 `{livekit_url, token, session_id, expires_at}`
    字段（原生免解 fragment；fragment 形式保留给 web）；
-4. `remote_dialer_status()` 的字段清单文档化（App 首页线路状态依赖它）。
+4. ~~`remote_dialer_status()` 的字段清单文档化~~（已落地：见 §一 `GET /api/device` 字段说明）。
 
 ## 五、Hosted 云控制面 `/v1`
 
@@ -134,6 +146,9 @@ adapter；原有 Tunnel `/api/*` adapter 与已保存凭证保持不变。Hosted
   和 `expiresAt` 后连接 LiveKit，不解析 URL fragment。
 - LiveKit 的 `callpilot.control` / `callpilot.status` topic 和 `media_ready` 后才发送
   `dial` 的门控语义与 Tunnel 共用，不因控制面协议改变。
+- 信令边界：通话中 `dial`/`dtmf`/`hangup` 与 `status` 事件经 **LiveKit data packets
+  在参与者间直传**；云 Durable Object 只承载 Edge WSS（`session.start` 下发与状态/ACK
+  上报），不中转房间信令或媒体。
 - Hosted 与 Tunnel 配对链接都可能使用根路径，App 不按 URL 形态猜协议。自动模式先向同一
   origin 提交 hosted claim；仅当 `/v1/pairing-sessions/claim` 返回 404/405 时回退
   `/api/pair`。业务错误不回退，避免重复提交已被服务端处理的配对码；界面仍保留显式协议选择兜底。


### PR DESCRIPTION
> Draft：#44 实现分支 PR。编码 + 单测 + 两轮独立 review 已完成；**真机验收（Edge 云模式拨 10000）完成后转正**。

## 背景

Edge 云托管模式（`REMOTE_CLOUD_ENABLED=true`）与本机 Tunnel 网关互斥，此前 App 在云模式下完全不可用（502）。本 PR 让 App 学会 hosted `/v1` 协议，按配对来源自动选栈，与既有 Tunnel 协议双栈共存。Refs #44。

## 改动（commit `691d211`）

- **协议层**：新增 `HostedCloudClient`（`/v1` 配对 claim、设备状态、呼叫创建/轮询、解除配对），与 `GatewayClient`（Tunnel）并存为独立 adapter；轮询以服务端 `expiresAt`（epoch ms）为 deadline、前 3s 每 250ms 后每 1s 渐进、过期 ready 视为无效响应；POST 传输级失败同 `idempotencyKey` 重试一次；callId/edgeId/session 防混淆校验。
- **协议协商**：新增 `PairingProtocol`（`tunnel|hosted`）+ 同源自动协商——先 `/v1/pairing-sessions/claim`，仅 404/405（路由不存在）回退 `/api/pair`，业务错误不回退；UI 保留显式协议选择兜底。`CredentialStore` 持久化协议与云 `edgeId`，**无标记旧数据一律按 tunnel 读**（升级不丢配对）。
- **通话**：`CallManager` 按配对来源选栈，保持 media_ready 门控后才发 dial 的语义；闭合挂断/dial 竞态（`commandLock` + `hangupRequested` + LAZY `dialJob`，锁内注册、双重活跃性检查）；`CallState.Failed` 透传稳定 `error.code`（`EDGE_OFFLINE`/`LINE_BUSY`/…）。
- **安全**：`DeviceCredential`/`HostedPairResult`/`HostedCallSession` 的 `toString()` 脱敏（secret/token → `***`），配套单测断言。
- **文档**（commit `6d74d59`，Refs #37）：`docs/remote-protocol.md` 新增 §五 hosted 原生端差异（SSOT 指向 `remote-cloud-protocol.md`）；并按 #37 审计修正四处契约表述（基线、`type=remote_call` 归属、`app-*` defer、`/api/device.edge` 字段精确化）+ 澄清 DO/data-packets 信令边界。

## 验证与 review 记录

- [x] `./gradlew assembleDebug lint test` 全绿（本机两轮：修正前后各一轮）
- [x] JVM 单测 63 项全绿（新增：挂断/media_ready 交错时序、deadline 渐进轮询、同 key 重试、错误码透传、toString 脱敏、404 协商回退等）
- [x] 独立 review 第 1 轮（只读）：判 **BLOCK**——1×P0（挂断竞态）+ 5×P1，全部修复
- [x] 独立 review 第 2 轮（跨模型对抗复审全量修正 diff）：**APPROVE**，无 P0/P1；并额外核verify `/v1/device` 的 `edge.connected/modemOnline` 与云端 presence 字段严格对齐
- [x] 测试环境修正一处（维护者）：同 key 重试测试由 MockWebServer+禁路由回退改为纯 interceptor 合成响应（localhost 双栈下的 ConnectException 与被测逻辑无关）
- [ ] Android CI 绿
- [ ] 真机验收（Edge 云模式，RC Edge）：配对 → 拨 10000 → media_ready 门控 → 接通 → DTMF → 挂断
- [ ] 旧 Tunnel 配对回归：既有配对继续可用

## 遗留（非阻塞 backlog）

- P2：`POST /v1/calls` 响应若已带 ready+session，当前仍统一走一次 GET 轮询（快速接通多一个 RTT）。
- P2：hosted 服务临时 404（如 Worker 故障）会触发协商回退到 Tunnel 并以 Tunnel 错误呈现，文案可能误导；概率低。
- 云端（另行跟进）：`GET /v1/calls/{id}` 失败缺稳定 `failureCode`（生产 DNS 前 P1）；PWA `display_name`/`displayName` 字段错位已在 0.6.0 RC 批次修复。

## 真机纪律

外呼一律只拨 10000（免费客服热线，项目铁律）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3ym8uHa4Xq46rZBDCXaDb
