### PR TITLE
0.6.0 RC：hosted onboarding + Android v0，修 PWA 设备名（#45）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -154,7 +154,7 @@ TOOL_QUERY_CODE_ENABLED=true
 REMOTE_WEB_DIALER_ENABLED=false
 # 普通 Beta 用户启用公司托管控制面：无需 Cloudflare Tunnel 或本地 LiveKit 密钥。
 REMOTE_CLOUD_ENABLED=false
-REMOTE_CLOUD_URL=https://api.bondings.ai
+REMOTE_CLOUD_URL=https://api-beta.bondings.ai
 REMOTE_MEDIA_PROVIDER=livekit
 # 远程真人拨号默认用模组 QVTS；both 同时发送 QVTS 与带内双音。
 REMOTE_DTMF_MODE=qvts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to CallPilot are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 versioning follows [SemVer](https://semver.org/) (pre-1.0: minor bumps may break).
 
+## [0.6.0] — 2026-07-12
+
+First build that ships the hosted remote control plane, so an ordinary user can
+pair a phone and dial through the Dongle SIM without hand-setting up a tunnel.
+
+### Added
+
+- **Hosted cloud onboarding**: the packaged app now bundles the hosted control
+  plane client (Cloudflare Worker + LiveKit); pairing a phone works over the
+  managed `*-beta.bondings.ai` endpoints with a pairing code, without manual
+  tunnel setup. (#42)
+- **Android remote dialer**: first native Android client for dialing through the
+  Dongle SIM from a phone. (#36)
+
+### Fixed
+
+- **Hosted dialer showed a blank paired-device name**: the browser dialer read
+  the snake_case `display_name`, but the `/v1` API returns camelCase
+  `displayName`, so the paired-device label was always empty. Aligned the field
+  and locked it with a static regression test.
+
 ## [0.5.6] — 2026-07-11
 
 Skips 0.5.5, which was only ever a local test build (packaged before the

--- a/cloud/public/remote_dialer.js
+++ b/cloud/public/remote_dialer.js
@@ -143,7 +143,7 @@
     pairingSurface.hidden = true;
     callSurface.hidden = false;
     pairedRow.hidden = !device;
-    pairedDevice.textContent = device ? device.display_name : "";
+    pairedDevice.textContent = device ? device.displayName : "";
   }
 
   function stopMicrophone() {

--- a/cloud/test/static.test.ts
+++ b/cloud/test/static.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 
 const script = readFileSync(join(process.cwd(), "public", "remote_dialer.js"), "utf8");
 const page = readFileSync(join(process.cwd(), "public", "index.html"), "utf8");
+const indexSource = readFileSync(join(process.cwd(), "src", "index.ts"), "utf8");
 
 describe("hosted dialer", () => {
   it("uses the cloud pairing and call resources", () => {
@@ -14,10 +15,12 @@ describe("hosted dialer", () => {
   });
 
   it("reads the paired device name via the camelCase field the /v1 API returns", () => {
-    // /v1 device payloads are camelCase (schemas.ts deviceSchema.displayName);
-    // reading the snake_case DB column left the paired-device label always blank.
+    // The dialer reads device.displayName; reading the snake_case DB column left
+    // the paired-device label always blank. Lock both sides so neither drifts.
     expect(script).toContain("device.displayName");
     expect(script).not.toContain("device.display_name");
+    // Producer side: getDevice maps the snake_case DB column to the camelCase API key.
+    expect(indexSource).toContain("displayName: device.display_name");
   });
 
   it("does not render server strings through HTML injection sinks", () => {

--- a/cloud/test/static.test.ts
+++ b/cloud/test/static.test.ts
@@ -13,6 +13,13 @@ describe("hosted dialer", () => {
     expect(script).toContain('fetch(`/v1/calls/${encodeURIComponent(payload.callId)}`');
   });
 
+  it("reads the paired device name via the camelCase field the /v1 API returns", () => {
+    // /v1 device payloads are camelCase (schemas.ts deviceSchema.displayName);
+    // reading the snake_case DB column left the paired-device label always blank.
+    expect(script).toContain("device.displayName");
+    expect(script).not.toContain("device.display_name");
+  });
+
   it("does not render server strings through HTML injection sinks", () => {
     expect(script).not.toMatch(/\.innerHTML\s*=/);
     expect(script).not.toContain("insertAdjacentHTML");

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "callpilot"
-version = "0.5.6"
+version = "0.6.0"
 description = "Open-source AI phone agent on a Quectel 4G modem: auto-answers, talks with a realtime voice AI, dials out, and sends/receives SMS."
 requires-python = ">=3.12"
 readme = "README.md"

--- a/src/agentcall/config.py
+++ b/src/agentcall/config.py
@@ -294,9 +294,9 @@ CONFIG_SPECS: tuple[ConfigSpec, ...] = (
     ConfigSpec("REMOTE_CLOUD_ENABLED", "使用 CallPilot 云控制面", "bool", "false",
                requires_restart=True),
     ConfigSpec("REMOTE_CLOUD_URL", "CallPilot 云控制面地址", "str",
-               "https://api.bondings.ai", requires_restart=True),
+               "https://api-beta.bondings.ai", requires_restart=True),
     ConfigSpec("REMOTE_CLOUD_DIALER_URL", "CallPilot 手机拨号地址", "str",
-               "https://dial.bondings.ai/", editable=False, hidden=True),
+               "https://dial-beta.bondings.ai/", editable=False, hidden=True),
     ConfigSpec("REMOTE_MEDIA_PROVIDER", "远程媒体服务", "select", "livekit",
                choices=("livekit",)),
     # EC20/EG25 真机验证：UAC 路径只注入带内双音时，运营商 IVR 可能不识别；

--- a/tests/unit/test_remote_cloud_web_api.py
+++ b/tests/unit/test_remote_cloud_web_api.py
@@ -120,7 +120,7 @@ def test_dashboard_enrolls_then_manages_cloud_pairing_without_returning_secret(m
             pairing = await client.post("/api/remote_dialer/pairing", json={})
             pairing_body = await pairing.json()
             assert pairing_body["pairing"]["url"] == (
-                "https://dial.bondings.ai/#pair=ABCD-EFGH"
+                "https://dial-beta.bondings.ai/#pair=ABCD-EFGH"
             )
 
             devices = await client.get("/api/remote_dialer/devices")


### PR DESCRIPTION
RC 批次 for #45：第一个含 hosted 云控制面 + Android v0 的 0.6.0 签名公证发布，让普通用户扫码即用 hosted onboarding（指向 beta 域名，不动生产 DNS）。

## 改动

- 版本 bump 0.5.6 → 0.6.0（pyproject 单一出处 → agentcall.spec 自动读 CFBundle）
- 修 PWA 设备名恒空：`remote_dialer.js` 读驼峰 `device.displayName`（与 /v1 契约一致）+ cloud static 双向字段对齐回归测试
- hosted 默认端点指 beta：`REMOTE_CLOUD_URL`→`api-beta.bondings.ai`、`REMOTE_CLOUD_DIALER_URL`→`dial-beta.bondings.ai`（+ .env.example / 扫码断言同步）
- CHANGELOG [0.6.0]

## Review（DoD 他人 review）

- round1 codex：**BLOCK** —— 默认端点指生产（`api.bondings.ai` DNS 不解析、`dial.bondings.ai` 530），会让全新 RC 扫码配对失败。
- 修复后 round2 codex：**APPROVE** —— 独立验证清 env 后 `get_str` 返 beta URL、beta 两域 /healthz 200、定向 Python 60 passed。

## 全面测试

- Python：pytest 704 passed（1 `test_keychain` 为本机 .venv 缺 keyring 的环境 fail，主仓同样、CI 有全依赖）、ruff clean、mypy clean
- cloud：`npm run check` 全绿（tsc + eslint + vitest 12 + integration）
- 产物：签名公证 DMG，`--selftest` exit 0 / 17 模块全 OK（cloud_control / livekit 等真进 bundle）、CFBundleShortVersionString=0.6.0、Gatekeeper accepted（Notarized Developer ID）

## Release 门禁（未完成，故 Draft）

- [ ] 真机 #45 hosted onboarding 走查（普通用户扫码路径实连 beta）
- [ ] push 后 CI 三平台矩阵绿

## 非阻断 backlog（codex 建议，不阻本 RC）

- integration 断言 `claim` + `/v1/device` 两条 payload 的 `displayName`（现 producer 锁只覆盖 getDevice）
- `.env.example` ↔ ConfigSpec 默认值一致断言（现只锁 key 存在）
- bundle 加纯数字 `CFBundleVersion`（候选迭代追踪）

Refs #45 #42 #30
