### PR TITLE
docs+ci: 0.6.1 文档一致性 + 供应链 CI 基线（#49）

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,11 +1,11 @@
 # Contributing to CallPilot / 贡献指南
 
-> **v0.1 Developer Preview.** The single most valuable contribution right now is a
+> **Mac Beta (0.6.x).** The single most valuable contribution right now is still a
 > **hardware reproduction report** from anyone running a Quectel EC20/EG25. See
 > [Hardware contributors](#hardware-contributors) below and open a
 > [Hardware reproduction report](../../issues/new?template=hardware-report.yml).
 >
-> **v0.1 开发者预览版。** 现阶段最有价值的贡献是**同型号硬件的复现报告**——参见下方
+> **Mac Beta（0.6.x）。** 现阶段最有价值的贡献仍是**同型号硬件的复现报告**——参见下方
 > [硬件贡献者](#硬件贡献者)，并开一个
 > [硬件复现报告](../../issues/new?template=hardware-report.yml) issue。
 
@@ -98,12 +98,14 @@ convention:
 
 ### Release process
 
-Since 0.6.0, every GitHub Release notes block records — for supply-chain
-auditability — the git tag, the packaged DMG's SHA-256, the Apple notarization
-submission id, and the exact build-source commit (which may predate the merge
-commit when Android/docs-only changes don't enter the desktop DMG). Any cloud
-PWA change must be `wrangler deploy`-ed to the beta endpoints before the Release
-is cut, so the hosted onboarding a user hits matches the released source.
+From the next release (0.6.1) onward, every GitHub Release notes block must
+record — for supply-chain auditability — the packaged DMG's SHA-256, the Apple
+notarization submission id, the exact build-source commit (which may predate the
+merge commit when Android/docs-only changes don't enter the desktop DMG), and
+the git tag. (The v0.6.0 notes already carry the DMG SHA-256, build source, and
+signing result; the notarization submission id is folded in from 0.6.1.) Any
+cloud PWA change must be `wrangler deploy`-ed to the beta endpoints before the
+Release is cut, so the hosted onboarding a user hits matches the released source.
 
 ### Hardware contributors
 
@@ -179,11 +181,11 @@ cp .env.example .env                 # 然后按需编辑 .env
 - `tests/conftest.py` 会自动隔离副作用：把 `CALL_LOG_DIR` 指向临时目录，并设
   `SUMMARY_ENABLED=false`，使测试不写你的真实录音目录、也不触网。需要不同行为的
   测试可自行 `monkeypatch.setenv` / `delenv`——测试级优先于该 fixture。
-- 开 PR **之前**请先跑 `.venv/bin/pytest` 并确保全绿。
+- 开 PR **之前**请先跑三件套（`.venv/bin/ruff check .`、`.venv/bin/mypy`、`.venv/bin/pytest`）并确保全绿。
 
 ### 代码风格
 
-与现有代码保持一致——目前尚未强制统一的 linter/formatter，靠约定保持一致：
+与现有代码保持一致。三件套在 CI 中为每次改动把关、推送前须全绿：`.venv/bin/ruff check .`（lint）、`.venv/bin/mypy`（类型）、`.venv/bin/pytest`（测试）；此外的风格靠约定：
 
 - **中文 docstring 与注释。** 模块/类/函数的 docstring 与注释用中文（参见
   `src/agentcall/` 下任意文件）。新代码保持一致；面向来电方/界面的用户可见文案，在
@@ -201,7 +203,7 @@ cp .env.example .env                 # 然后按需编辑 .env
 
 - 从 `main` **切分支**，不要直接提交到 `main`。分支名简短达意（如
   `fix/second-call-silent`、`feat/dtmf-tool`）。
-- **先跑测试。** 推送前 `.venv/bin/pytest` 必须全绿。
+- **先跑三件套。** 推送前 `.venv/bin/ruff check .`、`.venv/bin/mypy`、`.venv/bin/pytest` 必须全绿。
 - **Commit 信息**简洁、说清 *做了什么/为什么*；映射到 `docs/roadmap.md` 的任务时，
   欢迎带上路线图任务 ID 前缀（如 `P0-1`）。中英文皆可，与历史保持一致。
 - PR 保持聚焦。描述里写清**改了什么**、**为什么**、**如何验证**（测试输出；若涉及

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -56,12 +56,15 @@ to contribute code or run tests.
   temp dir and sets `SUMMARY_ENABLED=false` so tests never write to your real
   recordings dir or hit the network. A test that needs different behavior can
   `monkeypatch.setenv` / `delenv` — test-level env wins over the fixture.
-- Please run `.venv/bin/pytest` and get a green suite **before** opening a PR.
+- Please run the three gates — `.venv/bin/ruff check .`, `.venv/bin/mypy`,
+  `.venv/bin/pytest` — and get them all green **before** opening a PR.
 
 ### Code style
 
-Match the existing code — no separate linter/formatter is enforced yet, so
-consistency is by convention:
+Match the existing code. Three gates run in CI and gate every change — keep all
+three green before you push: `.venv/bin/ruff check .` (lint), `.venv/bin/mypy`
+(types), and `.venv/bin/pytest` (tests). Beyond those, consistency is by
+convention:
 
 - **Chinese docstrings and inline comments.** Module/class/function docstrings and
   comments are written in Chinese (see any file under `src/agentcall/`). Keep new
@@ -82,7 +85,8 @@ consistency is by convention:
 
 - **Branch** off `main`; don't commit to `main` directly. Use a short descriptive
   branch name (e.g. `fix/second-call-silent`, `feat/dtmf-tool`).
-- **Run the tests first.** `.venv/bin/pytest` must be green before you push.
+- **Run the three gates first.** `.venv/bin/ruff check .`, `.venv/bin/mypy`, and
+  `.venv/bin/pytest` must all be green before you push.
 - **Commit messages** are concise and describe the *what/why*; a leading roadmap
   task ID (e.g. `P0-1`) is welcome when it maps to `docs/roadmap.md`. Chinese or
   English are both fine — match the surrounding history.
@@ -91,6 +95,15 @@ consistency is by convention:
   observations, since CI cannot exercise the modem).
 - If your change touches a hardware/audio path that the test suite can't cover,
   say so explicitly and describe your manual verification.
+
+### Release process
+
+Since 0.6.0, every GitHub Release notes block records — for supply-chain
+auditability — the git tag, the packaged DMG's SHA-256, the Apple notarization
+submission id, and the exact build-source commit (which may predate the merge
+commit when Android/docs-only changes don't enter the desktop DMG). Any cloud
+PWA change must be `wrangler deploy`-ed to the beta endpoints before the Release
+is cut, so the hosted onboarding a user hits matches the released source.
 
 ### Hardware contributors
 
@@ -158,7 +171,7 @@ cp .env.example .env                 # 然后按需编辑 .env
 .venv/bin/pytest
 ```
 
-- **无需硬件、无需联网、无需 API Key。** 当前 160 个用例可完全离线运行。
+- **无需硬件、无需联网、无需 API Key。** 整个用例集可完全离线运行。
 - 测试使用 `tests/fakes/` 下的内存**假件**，与真实组件鸭子类型对齐：`FakeModem`
   （对齐 `Eg25Modem`，记录 AT 调用并可触发 `RING`/挂断/短信）、`FakeAudioBridge`
   （内存环回音频桥，接口与 `ModemAudioBridge` 对齐）、`FakeAgent`（脚本化的

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported          |
 |---------|--------------------|
-| 0.2.x   | ✅ current release |
-| < 0.2   | ❌                 |
+| 0.6.x   | ✅ current release |
+| < 0.6   | ❌                 |
 
 Pre-1.0, only the latest minor release receives fixes.
 
@@ -30,7 +30,11 @@ In scope:
 - The CallPilot source tree (`src/agentcall`, `app.py`, `desktop_app.py`),
   helper scripts, and packaging.
 - The local web dashboard and its HTTP/WebSocket API.
-- How CallPilot handles credentials stored in your `.env`.
+- The hosted control plane (`cloud/`: Cloudflare Worker + D1 + Durable Objects)
+  and its `/v1` pairing/call API, plus the LiveKit media-relay path it brokers.
+- The Android remote-dialer app (`android/`) and its pairing/credential storage.
+- How CallPilot handles credentials stored in your `.env` and the device
+  credentials issued by the hosted control plane.
 
 Out of scope:
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  # Python (pyproject.toml / requirements)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+  # Cloud control plane (Cloudflare Worker)
+  - package-ecosystem: "npm"
+    directory: "/cloud"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+  # Android remote-dialer app
+  - package-ecosystem: "gradle"
+    directory: "/android"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+  # GitHub Actions used by the workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,6 +15,9 @@ concurrency:
   group: android-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: assemble + lint + unit tests
@@ -23,16 +26,16 @@ jobs:
       run:
         working-directory: android
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: "21"
 
       - name: Setup Gradle (缓存依赖与分发)
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
 
       - name: Build debug APK
         run: ./gradlew :app:assembleDebug --no-daemon
@@ -44,7 +47,7 @@ jobs:
         run: ./gradlew :app:testDebugUnitTest --no-daemon
 
       - name: Upload APK artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: callpilot-debug-apk
           path: android/app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:
@@ -20,9 +23,9 @@ jobs:
         python-version: ["3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/cloud-ci.yml
+++ b/.github/workflows/cloud-ci.yml
@@ -20,8 +20,8 @@ jobs:
       run:
         working-directory: cloud
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,39 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "25 3 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # kotlin (java-kotlin) 需要 gradle 编译配置，后续单独接入；
+        # 先覆盖免编译语言，确保基线可靠绿。
+        language: [python, javascript-typescript]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3
+        with:
+          languages: ${{ matrix.language }}
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@02c5e83432fe5497fd85b873b6c9f16a8578e1d9 # v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/Python-3.12%2B-3776AB.svg?logo=python&logoColor=white)](https://www.python.org/)
 [![Platform: macOS | Windows (beta)](https://img.shields.io/badge/Platform-macOS%20%7C%20Windows%20(beta)-000000.svg?logo=apple&logoColor=white)](#hardware--platform-support)
-[![Status: Developer Preview](https://img.shields.io/badge/Status-Developer_Preview-orange.svg)](docs/roadmap.md)
+[![Status: Mac Beta](https://img.shields.io/badge/Status-Mac_Beta-orange.svg)](docs/roadmap.md)
 
 **Your calls, handled by AI.** An open-source AI phone agent that runs on a
 Quectel EC20/EG25 4G modem: it auto-answers incoming calls and talks to the
@@ -11,9 +11,11 @@ caller with a realtime voice AI, places outbound calls, sends/receives SMS,
 navigates IVR menus (DTMF), and records + summarizes every call — all on your
 own hardware and API keys.
 
-> **Status: Mac Beta (v0.5.0).** Runs on macOS with a Quectel EC20 today.
-> Developers can run from source; regular users can install the signed,
-> notarized macOS DMG from the latest GitHub Release. See [Roadmap](docs/roadmap.md).
+> **Status: Mac Beta (v0.6.0).** Runs on macOS with a Quectel EC20 today.
+> Developers can run from source; regular users install the signed, notarized
+> macOS DMG from the latest GitHub Release. As of 0.6.0 an optional hosted cloud
+> control plane lets you pair a phone and dial through the modem remotely with a
+> pairing code — no self-hosted tunnel needed. See [Roadmap](docs/roadmap.md).
 
 [English](#english) · [中文](#中文)
 
@@ -43,7 +45,7 @@ Phone call → EC20 modem ──(AT: RING/ATA/CLCC)── CallPilot
   **DTMF keypad**), per-call recording + latency metrics + LLM summary, live
   transcript, local speaker monitoring, bilingual (English/Chinese) desktop UI.
 
-**New in v0.5.0 — local three-stage provider** (`AGENT_PROVIDER=local`):
+**Local three-stage provider** (`AGENT_PROVIDER=local`, added in v0.5.0):
 on-device VAD → STT → text LLM → on-device TTS. Audio never leaves your
 machine; only the transcript goes to the text brain (default `qwen-plus`,
 same DashScope key, an order of magnitude cheaper than realtime audio).
@@ -343,7 +345,7 @@ Quectel EC20/EG25，来电自动接听并与对方对话，可外呼、收发短
   （发短信/挂断/查验证码/**DTMF 按键**）、通话录音+摘要、实时转写、本机监听、
   中英双语桌面界面。
 
-**v0.5.0 新增——本地三段式 provider**（`AGENT_PROVIDER=local`）：本地 VAD →
+**本地三段式 provider**（`AGENT_PROVIDER=local`，v0.5.0 引入）：本地 VAD →
 本地转写 → 云端文本模型 → 本地合成。音频不出本机，只有转写文本上云（默认
 `qwen-plus`，同一个 DashScope key，比 realtime 音频便宜一个量级）。启用：
 `pip install 'callpilot[local]'` 后运行 `python -m agentcall.local_models`

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ New-user install & first-run Q&A: [`docs/faq.md`](docs/faq.md) (Chinese).
 
 ### Contributing
 
-Developer Preview wants hardware reproduction reports. If you have an EC20, please
+Mac Beta still wants hardware reproduction reports. If you have an EC20, please
 open an issue with your modem firmware, macOS version, and what worked / didn't.
 Tests: `.venv/bin/pytest` (no hardware needed — uses fake modem/bridge/agent).
 
@@ -331,6 +331,11 @@ License: [Apache-2.0](LICENSE).
 ---
 
 ## 中文
+
+> **状态：Mac Beta（v0.6.0）。** 今天可在装有 Quectel EC20 的 macOS 上运行。开发者可从
+> 源码运行；普通用户从最新 GitHub Release 安装已签名公证的 macOS DMG。0.6.0 起提供可选的
+> hosted 云控制面，用配对码即可让手机远程通过模组拨号，无需自建 tunnel。见
+> [路线图](docs/roadmap.md)。
 
 ### 这是什么
 
@@ -551,7 +556,7 @@ macOS 上 `CallPilot.app` 是**菜单栏 App**：顶栏一个电话图标（绿=
 
 ### 贡献
 
-Developer Preview 阶段最需要同型号硬件的复现反馈。有 EC20 的话，欢迎带上模组固件、
+Mac Beta 阶段仍最需要同型号硬件的复现反馈。有 EC20 的话，欢迎带上模组固件、
 macOS 版本、以及哪里成功/失败开 issue。测试：`.venv/bin/pytest`（无需硬件）。
 
 架构与「想改 X 去哪」见 [`docs/architecture.md`](docs/architecture.md)；想单独学习/验证某个

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,8 +2,8 @@
 
 > 版本：v2.2（2026-07-12）
 > 本文合并原 `01-requirements.md` / `02-task-breakdown.md` / `03-gap-analysis-vs-poc.md`，
-> 是当前唯一的计划文档。**本地三段式（VAD→STT→LLM→TTS）方案已整体延后**，本文只覆盖
-> 云端 realtime 路线下要做的功能，按优先级组织。三段式方案见文末附录 A（暂缓）。
+> 是当前唯一的计划文档。本文主线按云端 realtime 路线组织；**本地三段式（VAD→STT→LLM→TTS）
+> 已作为第四 provider `local` 落地**（2026-07-10，见文末附录 A），可与云端 provider 切换。
 > codex 评审全过程留存于 `.codex_dialog.md`；旧版三份文档留存于 git 历史（commit 08754fc）。
 >
 > **状态更新（v0.2，2026-07-08）**：FR-7/9/10/11（桌面 App、批量外呼、通话记录/录音、
@@ -11,19 +11,19 @@
 > provider 由 qwen/doubao 扩展为 **qwen（默认）/ doubao / openai**。
 >
 > **状态更新（0.6.0，2026-07-12）**：hosted 云控制面（Cloudflare Worker + D1 +
-> Durable Objects + LiveKit，见 #42/#43）与 Android 远程拨号 App（hosted `/v1` 协议，
-> 见 #36/#44）已发布——普通用户用配对码即可远程拨号，无需自建 tunnel。0.6.0 签名公证
-> DMG 已发 GitHub Release；hosted onboarding 指向 `*-beta.bondings.ai`，生产 DNS 切换
-> 待异网混沌验收后单独进行。
+> Durable Objects + LiveKit，见 #42/#43）已随 0.6.0 签名公证 DMG 发 GitHub Release，
+> 普通用户用配对码即可让手机远程通过模组拨号、无需自建 tunnel。Android 远程拨号 App
+> 的源码 / hosted `/v1` 协议 / 真机验收已落地（#36/#44），正式签名分发（AAB）待 0.7。
+> hosted onboarding 指向 `*-beta.bondings.ai`，生产 DNS 切换待异网混沌验收后单独进行。
 
 ## 0. 发布路线（开源 + 商业化免费）
 
 | 版本 | 目标 | 面向 | 状态 |
 |------|------|------|------|
-| **v0.1 Developer Preview** | 源码开源，开发者按 README 手动跑通，收集同型号 EC20 硬件反馈 | 会装 Python/填 Key/跑命令的开发者 | 🚧 本轮交付：Apache-2.0、去个人化、双语 README、风险声明、仓库清理 |
+| **v0.1 Developer Preview** | 源码开源，开发者按 README 手动跑通，收集同型号 EC20 硬件反馈 | 会装 Python/填 Key/跑命令的开发者 | ✅ 已落地（Apache-2.0、去个人化、双语 README、风险声明、仓库清理） |
 | **v0.2 Mac Beta** | 有 `.app`，仍需装依赖或跑安装脚本 | 技术用户 | ✅ 已落地 |
 | **v0.3 One-click Mac Beta** | `.dmg` 安装、首次启动向导、内置 runtime、自动 launchd、Developer ID 签名+公证 | 普通用户 | ✅ 已落地（v0.4.0 起 DMG 已签名+公证+staple） |
-| **v0.6.0 Hosted + Mobile** | hosted 云控制面（Cloudflare Worker + D1 + Durable Objects + LiveKit）+ Android 远程拨号 App，配对码远程拨号、无需自建 tunnel | 普通用户 | ✅ 已发布（2026-07-12；#42/#43 云控制面、#36/#44 Android v0 + hosted `/v1`） |
+| **v0.6.0 Hosted 桌面** | hosted 云控制面（Cloudflare Worker + D1 + Durable Objects + LiveKit）签名公证 DMG，配对码远程拨号、无需自建 tunnel；Android 远程拨号 App 源码/协议/真机验收已落地、正式分发待 0.7 | 普通用户（桌面 DMG） | ✅ 已发布（2026-07-12；#42/#43 云控制面、#36/#44 Android v0 + hosted `/v1`） |
 | **v1.0** | 稳定硬件矩阵、隐私说明、故障恢复、完整文档 | 通用 | 计划 |
 
 v0.1 原则（codex 建议，已采纳）：不追求一键安装，追求"陌生开发者 30 分钟能跑通、能提
@@ -283,7 +283,7 @@ provider 外呼静默失效、WS 推送偶发丢事件、hangup 无锁等）→ 
 ## 6. 关键决策与现状事实（保留）
 
 - **D1 以 AA 为基座**：AA 的 modem/音频/会话编排真机已跑通，整体迁入重组，未反向改造 poc。
-- **D2 realtime 优先，三段式延后**：当前只走云端 realtime；本地三段式作为未来可选 provider（附录 A）。
+- **D2 realtime 优先，三段式为可选 provider**：主线走云端 realtime；本地三段式已作为第四 provider `local` 落地（附录 A），可切换。
 - **D3 音频模式（双向均已真机验证）**：
   - 已证实：`uac`(PortAudio/sounddevice) 在本机**打不开** EC20 声卡（AUHAL -66740/-9986，
     coreaudiod 异常时更甚）；`nmea`(USB 串口 PCM) 在本机会**触发 USB 接口崩溃重枚举**

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # CallPilot 需求与路线图（Realtime 优先，单一 SSOT）
 
-> 版本：v2.1（2026-07-07）
+> 版本：v2.2（2026-07-12）
 > 本文合并原 `01-requirements.md` / `02-task-breakdown.md` / `03-gap-analysis-vs-poc.md`，
 > 是当前唯一的计划文档。**本地三段式（VAD→STT→LLM→TTS）方案已整体延后**，本文只覆盖
 > 云端 realtime 路线下要做的功能，按优先级组织。三段式方案见文末附录 A（暂缓）。
@@ -9,6 +9,12 @@
 > **状态更新（v0.2，2026-07-08）**：FR-7/9/10/11（桌面 App、批量外呼、通话记录/录音、
 > 通话后摘要）、首启向导、DMG 安装包、P0/P1/P2 主线与 §3 多数 P3 打磨项已回填状态；
 > provider 由 qwen/doubao 扩展为 **qwen（默认）/ doubao / openai**。
+>
+> **状态更新（0.6.0，2026-07-12）**：hosted 云控制面（Cloudflare Worker + D1 +
+> Durable Objects + LiveKit，见 #42/#43）与 Android 远程拨号 App（hosted `/v1` 协议，
+> 见 #36/#44）已发布——普通用户用配对码即可远程拨号，无需自建 tunnel。0.6.0 签名公证
+> DMG 已发 GitHub Release；hosted onboarding 指向 `*-beta.bondings.ai`，生产 DNS 切换
+> 待异网混沌验收后单独进行。
 
 ## 0. 发布路线（开源 + 商业化免费）
 
@@ -17,6 +23,7 @@
 | **v0.1 Developer Preview** | 源码开源，开发者按 README 手动跑通，收集同型号 EC20 硬件反馈 | 会装 Python/填 Key/跑命令的开发者 | 🚧 本轮交付：Apache-2.0、去个人化、双语 README、风险声明、仓库清理 |
 | **v0.2 Mac Beta** | 有 `.app`，仍需装依赖或跑安装脚本 | 技术用户 | ✅ 已落地 |
 | **v0.3 One-click Mac Beta** | `.dmg` 安装、首次启动向导、内置 runtime、自动 launchd、Developer ID 签名+公证 | 普通用户 | ✅ 已落地（v0.4.0 起 DMG 已签名+公证+staple） |
+| **v0.6.0 Hosted + Mobile** | hosted 云控制面（Cloudflare Worker + D1 + Durable Objects + LiveKit）+ Android 远程拨号 App，配对码远程拨号、无需自建 tunnel | 普通用户 | ✅ 已发布（2026-07-12；#42/#43 云控制面、#36/#44 Android v0 + hosted `/v1`） |
 | **v1.0** | 稳定硬件矩阵、隐私说明、故障恢复、完整文档 | 通用 | 计划 |
 
 v0.1 原则（codex 建议，已采纳）：不追求一键安装，追求"陌生开发者 30 分钟能跑通、能提


### PR DESCRIPTION
0.6.1 首批次（#49）：文档一致性 + 供应链安全基线。**纯文档 / CI / 配置，不改运行时行为。**

## 文档一致性
- **README**：状态行 v0.5.0→0.6.0 + hosted onboarding 说明；徽章 Developer Preview→Mac Beta；v0.5.0 local provider 段去时效标签（归档化）。
- **docs/roadmap.md**：版本 v2.2 + 0.6.0 状态更新 + 发布路线回填（#42/#43 Cloud 控制面、#36/#44 Android v0+hosted）。
- **CONTRIBUTING**：「无 lint 强制」→ 如实描述三件套 commit 门（ruff+mypy+pytest，三处一致）；「160 个用例」→ 不写死数字；新增 Release process 段（发版审计纪律）。
- **SECURITY**：支持矩阵 0.2.x→0.6.x；范围补 Cloud Worker / Android / LiveKit 链路。

## 供应链 / CI 基线
- 新增 `.github/dependabot.yml`（pip / npm / gradle / github-actions 四生态，weekly）。
- 新增 `.github/workflows/codeql.yml`（python + javascript-typescript）。
- 三个 workflow 的 actions 全部 pin 到 commit SHA（附 `# vX` 注释）。
- `ci.yml` / `android.yml` 补顶层 `permissions: contents: read`（`cloud-ci.yml` 已有）。

## 验证
- `ruff` / `mypy` clean、`pytest` 705 passed、5 个 `.github` YAML 语法校验通过、敏感扫描 clean。

## Review 迭代
- round1 codex review：BLOCK（5 项文档一致性——中英对齐 / Release 陈述 / Android 过度陈述 / 三段式 SSOT / 双语状态）→ commit `3e78779` 全修 → round2 codex：**APPROVE**。

## 合入后 / owner 待办（非本 PR 阻塞）
- **Security tab 状态（已核实 enabled）**：secret scanning、push protection、Dependabot security updates（vulnerability-alerts + automated-security-fixes）均已启用；version-update（dependabot.yml）+ CodeQL（codeql.yml）合入后自动生效。
- **SECURITY 安全邮箱**：现为占位（GitHub Security Advisories + maintainer profile），待 owner 提供专用安全联系地址。
- **CodeQL kotlin**（`java-kotlin`）需 gradle 编译配置，后续单独接入。

Refs #49
