### PR TITLE
安全: PWA Service Worker 排除认证 /v1 响应（#55）

### DIFF
--- a/cloud/public/remote_dialer_sw.js
+++ b/cloud/public/remote_dialer_sw.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const CACHE_NAME = "callpilot-cloud-v1";
+const CACHE_NAME = "callpilot-cloud-v2";
 const SHELL = [
   "/",
   "/remote_dialer.css?v=3",
@@ -29,7 +29,8 @@ self.addEventListener("activate", (event) => {
 self.addEventListener("fetch", (event) => {
   const url = new URL(event.request.url);
   if (event.request.method !== "GET" || url.origin !== self.location.origin) return;
-  if (url.pathname.startsWith("/api/")) return;
+  if (url.pathname.startsWith("/api/") || url.pathname.startsWith("/v1/")) return;
+  if (!SHELL.includes(`${url.pathname}${url.search}`)) return;
   event.respondWith(
     fetch(event.request)
       .then((response) => {

--- a/cloud/test/static.test.ts
+++ b/cloud/test/static.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 const script = readFileSync(join(process.cwd(), "public", "remote_dialer.js"), "utf8");
 const page = readFileSync(join(process.cwd(), "public", "index.html"), "utf8");
 const indexSource = readFileSync(join(process.cwd(), "src", "index.ts"), "utf8");
+const serviceWorker = readFileSync(join(process.cwd(), "public", "remote_dialer_sw.js"), "utf8");
 
 describe("hosted dialer", () => {
   it("uses the cloud pairing and call resources", () => {
@@ -33,6 +34,12 @@ describe("hosted dialer", () => {
     expect(script).not.toContain("localStorage");
     expect(script).not.toContain("sessionStorage");
     expect(script).not.toContain("Authorization");
+  });
+
+  it("only caches the shell and keeps API responses out of the service worker cache", () => {
+    expect(serviceWorker).toContain('url.pathname.startsWith("/api/")');
+    expect(serviceWorker).toContain('url.pathname.startsWith("/v1/")');
+    expect(serviceWorker).toContain('if (!SHELL.includes(`${url.pathname}${url.search}`)) return;');
   });
 
   it("allows the configured LiveKit Cloud discovery request", () => {


### PR DESCRIPTION
> Refs #55（#48 威胁建模 G-05）。SW 此前仅排除 /api/，会缓存含短期 LiveKit JWT 的 /v1/calls/{id}。

## 改动
- `remote_dialer_sw.js`：fetch handler 排除 /api/ **和 /v1/**（网络直取不进缓存）+ shell allowlist（仅精确静态资源可缓存）；cache name v1→v2，activate 清旧缓存。
- `static.test.ts`：补断言（SW 排除 API + shell allowlist）。

## 验证
- [x] codex vitest 12 passed；c-2 自审 APPROVE（改动最小、语义正确、冲突解决保留两 const）
- [ ] cloud CI 绿（本机 rolldown 原生绑定问题致 vitest 无法本地跑，交 CI 权威）
- [ ] merge 需 owner 批准

🤖 Generated with [Claude Code](https://claude.com/claude-code)