### PR TITLE
安全: DTMF 数字全路径日志脱敏，防 PIN 明文落盘（#53）

### DIFF
--- a/src/agentcall/agents/openai_agent.py
+++ b/src/agentcall/agents/openai_agent.py
@@ -373,8 +373,13 @@ class OpenAIVoiceAgent(VoiceAgent):
         try:
             try:
                 args = json.loads(arguments) if arguments.strip() else {}
-            except json.JSONDecodeError:
-                logger.warning("工具参数解析失败: %s", arguments)
+            except json.JSONDecodeError as exc:
+                logger.warning(
+                    "工具 %s 参数解析失败: arguments_length=%d, error_type=%s",
+                    name,
+                    len(arguments),
+                    type(exc).__name__,
+                )
                 args = {}
             if self._tools is not None:
                 # dispatch 可能有阻塞 IO（发短信/AT 指令），放线程池执行。

--- a/src/agentcall/agents/qwen_agent.py
+++ b/src/agentcall/agents/qwen_agent.py
@@ -682,8 +682,13 @@ class QwenVoiceAgent(VoiceAgent):
         def worker() -> None:
             try:
                 args = json.loads(arguments) if arguments.strip() else {}
-            except json.JSONDecodeError:
-                logger.warning("工具参数解析失败: %s", arguments)
+            except json.JSONDecodeError as exc:
+                logger.warning(
+                    "工具 %s 参数解析失败: arguments_length=%d, error_type=%s",
+                    name,
+                    len(arguments),
+                    type(exc).__name__,
+                )
                 args = {}
             result = (
                 self._tools.dispatch(name, args)

--- a/src/agentcall/agents/tools.py
+++ b/src/agentcall/agents/tools.py
@@ -99,6 +99,9 @@ QUERY_CODE_SPEC: dict[str, Any] = {
 # 触发 response.create，模型会在挂断延迟里多说一句（如“电话已经挂断…”），
 # 对端听到多余的话。故对这类工具只回传 function_call_output、不再要新回复。
 TERMINAL_TOOLS: frozenset[str] = frozenset({"hangup_call"})
+_DTMF_LOG_MODES: frozenset[str] = frozenset(
+    {"inband", "qvts", "both", "unknown"}
+)
 
 
 def _tool_name(spec: dict[str, Any]) -> str | None:
@@ -106,6 +109,16 @@ def _tool_name(spec: dict[str, Any]) -> str | None:
     if "function" in spec and isinstance(spec["function"], dict):
         return spec["function"].get("name")
     return spec.get("name")
+
+
+def _dtmf_count(args: dict[str, Any]) -> int:
+    digits = args.get("digits")
+    return len(digits.strip()) if isinstance(digits, str) else 0
+
+
+def _dtmf_log_mode(result: dict[str, Any]) -> str:
+    mode = result.get("mode")
+    return mode if isinstance(mode, str) and mode in _DTMF_LOG_MODES else "unknown"
 
 
 class ToolRegistry:
@@ -132,11 +145,40 @@ class ToolRegistry:
             logger.warning("请求了未知工具: %s", name)
             return {"success": False, "message": f"未知工具: {name}"}
         _spec, handler = entry
-        logger.info("执行工具 %s，参数=%s", name, args)
+        dtmf_count = _dtmf_count(args) if name == "send_dtmf" else None
+        if dtmf_count is None:
+            logger.info("执行工具 %s，参数=%s", name, args)
+        else:
+            logger.info("执行工具 %s: count=%d", name, dtmf_count)
         try:
             result = handler(args)
         except Exception as exc:  # noqa: BLE001
-            logger.exception("工具 %s 执行异常: %s", name, exc)
+            if dtmf_count is not None:
+                logger.error(
+                    "工具 %s 执行异常: count=%d, mode=unknown, "
+                    "result=failure, error_type=%s",
+                    name,
+                    dtmf_count,
+                    type(exc).__name__,
+                )
+            else:
+                logger.exception("工具 %s 执行异常: %s", name, exc)
+            if dtmf_count is not None:
+                return {
+                    "success": False,
+                    "count": dtmf_count,
+                    "mode": "unknown",
+                    "message": "按键发送失败",
+                }
             return {"success": False, "message": f"工具执行异常: {exc}"}
-        logger.info("工具 %s 执行结果=%s", name, result)
+        if dtmf_count is None:
+            logger.info("工具 %s 执行结果=%s", name, result)
+        else:
+            logger.info(
+                "工具 %s 执行结果: count=%d, mode=%s, result=%s",
+                name,
+                dtmf_count,
+                _dtmf_log_mode(result),
+                "success" if result.get("success") is True else "failure",
+            )
         return result

--- a/src/agentcall/call_agent.py
+++ b/src/agentcall/call_agent.py
@@ -814,13 +814,23 @@ class CallSession:
 
     def send_dtmf(self, digits: str) -> tuple[bool, str | None]:
         """发送 DTMF；UAC 模式默认把双音作为带内 PCM 注入下行队列。"""
+        mode = "unknown"
         try:
             ok, mode = self._send_dtmf_raw(digits)
         except Exception as exc:  # noqa: BLE001
-            logger.warning("发送 DTMF 失败: %s", exc)
+            logger.warning("发送 DTMF 失败: error_type=%s", type(exc).__name__)
+            if self._record is not None:
+                self._record.log_event(
+                    "dtmf", count=len(digits), mode=mode, result="failure"
+                )
             return False, "按键发送失败"
-        if ok and self._record is not None:
-            self._record.log_event("dtmf", digits=digits, mode=mode)
+        if self._record is not None:
+            self._record.log_event(
+                "dtmf",
+                count=len(digits),
+                mode=mode,
+                result="success" if ok else "failure",
+            )
         return (True, None) if ok else (False, "按键发送失败")
 
     def _send_dtmf_raw(self, digits: str) -> tuple[bool, str]:

--- a/src/agentcall/call_tools.py
+++ b/src/agentcall/call_tools.py
@@ -59,6 +59,7 @@ class CallTools:
         # None = 不限制(直接构造 CallTools 的单测保持旧行为)。
         self._is_sms_target_allowed = is_sms_target_allowed
         self._send_dtmf_impl = send_dtmf or self._send_dtmf_via_modem
+        self._dtmf_fallback_mode = "unknown" if send_dtmf else "qvts"
 
     def register(self) -> ToolRegistry:
         registry = ToolRegistry()
@@ -181,19 +182,41 @@ class CallTools:
         """工具处理：Agent 请求发送 DTMF 按键（IVR 导航）。"""
         digits = (args.get("digits") or "").strip()
         if not digits:
-            return {"success": False, "message": "按键序列为空"}
+            return {
+                "success": False,
+                "count": 0,
+                "mode": "unknown",
+                "message": "按键序列为空",
+            }
+        mode = self._dtmf_fallback_mode
         try:
             ok, mode = self._send_dtmf_impl(digits)
         except Exception as exc:  # noqa: BLE001
-            logger.warning("工具发送 DTMF 失败: %s", exc)
-            return {"success": False, "message": f"按键发送失败: {exc}"}
+            logger.warning("工具发送 DTMF 失败: error_type=%s", type(exc).__name__)
+            record = self._get_record()
+            if record is not None:
+                record.log_event(
+                    "dtmf", count=len(digits), mode=mode, result="failure"
+                )
+            return {
+                "success": False,
+                "count": len(digits),
+                "mode": mode,
+                "message": "按键发送失败",
+            }
         record = self._get_record()
-        if ok and record is not None:
-            record.log_event("dtmf", digits=digits, mode=mode)
+        if record is not None:
+            record.log_event(
+                "dtmf",
+                count=len(digits),
+                mode=mode,
+                result="success" if ok else "failure",
+            )
         return {
             "success": ok,
-            "digits": digits,
-            "message": f"已按 {digits}" if ok else "按键发送失败",
+            "count": len(digits),
+            "mode": mode,
+            "message": "按键发送成功" if ok else "按键发送失败",
         }
 
     def _send_dtmf_via_modem(self, digits: str) -> tuple[bool, str]:

--- a/src/agentcall/modem.py
+++ b/src/agentcall/modem.py
@@ -450,7 +450,7 @@ class Eg25Modem:
             return False
         valid = set("0123456789*#ABCD")
         if any(ch not in valid for ch in digits):
-            logger.warning("DTMF 含非法字符: %r", digits)
+            logger.warning("DTMF 输入无效: count=%d, result=failure", len(digits))
             return False
         for ch in digits:
             # Quectel EC20/EG25 用 AT+QVTS（部分固件也接受 AT+VTS）。
@@ -458,10 +458,10 @@ class Eg25Modem:
             if "OK" not in response:
                 response = self._send(f'AT+VTS="{ch}"')
             if "OK" not in response:
-                logger.warning("DTMF 按键 %s 发送失败: %r", ch, response.strip())
+                logger.warning("DTMF 发送失败: count=%d, result=failure", len(digits))
                 return False
             time.sleep(0.15)  # 位间间隔，防止连音被 IVR 吞掉
-        logger.info("已发送 DTMF: %s", digits)
+        logger.info("DTMF 发送完成: count=%d, result=success", len(digits))
         return True
 
     def hangup(self) -> None:

--- a/src/agentcall/remote_dialer.py
+++ b/src/agentcall/remote_dialer.py
@@ -443,8 +443,14 @@ class RemoteWebDialerCoordinator:
                 bridge.write_modem_chunks([tone])
         if mode in {"qvts", "both"}:
             ok = self.modem.send_dtmf(digits) and ok
-        if ok and self._record is not None:
-            self._record.log_event("dtmf", digits=digits, mode=mode, source=REMOTE_CALL_SOURCE)
+        if self._record is not None:
+            self._record.log_event(
+                "dtmf",
+                count=len(digits),
+                mode=mode,
+                result="success" if ok else "failure",
+                source=REMOTE_CALL_SOURCE,
+            )
         await self._send_ephemeral_status(
             "connected",
             event="dtmf_sent" if ok else "dtmf_failed",

--- a/tests/unit/test_call_service.py
+++ b/tests/unit/test_call_service.py
@@ -54,6 +54,18 @@ class FakeSmsEmailForwarder:
         self.stopped = True
 
 
+class SpyCallRecord:
+    def __init__(self) -> None:
+        self.downlink: list[bytes] = []
+        self.events: list[tuple[str, dict]] = []
+
+    def write_downlink(self, pcm: bytes) -> None:
+        self.downlink.append(pcm)
+
+    def log_event(self, type: str, **fields) -> None:  # noqa: A002
+        self.events.append((type, fields))
+
+
 class FakeRemoteCoordinator:
     def __init__(self) -> None:
         self.call_active = threading.Event()
@@ -217,22 +229,11 @@ def test_service_send_dtmf_requires_active_call():
 
 
 def test_service_send_dtmf_uses_inband_audio_for_uac(monkeypatch):
-    class SpyRecord:
-        def __init__(self) -> None:
-            self.downlink: list[bytes] = []
-            self.events: list[tuple[str, dict]] = []
-
-        def write_downlink(self, pcm: bytes) -> None:
-            self.downlink.append(pcm)
-
-        def log_event(self, type: str, **fields) -> None:  # noqa: A002
-            self.events.append((type, fields))
-
     monkeypatch.setenv("DTMF_MODE", "inband")
     modem = FakeModem()
     service = make_service(modem, audio_mode="uac")
     service.session._active = True
-    record = SpyRecord()
+    record = SpyCallRecord()
     service.session._record = record  # type: ignore[assignment]
 
     ok, err = service.send_dtmf("5")
@@ -245,7 +246,9 @@ def test_service_send_dtmf_uses_inband_audio_for_uac(monkeypatch):
     tone = bridge.downlink[0]
     assert len(tone) == int(8000 * 0.2) * 2
     assert record.downlink == [tone]
-    assert record.events == [("dtmf", {"digits": "5", "mode": "inband"})]
+    assert record.events == [
+        ("dtmf", {"count": 1, "mode": "inband", "result": "success"})
+    ]
 
 
 def test_service_send_dtmf_keeps_qvts_for_nmea(monkeypatch):
@@ -266,9 +269,37 @@ def test_service_send_dtmf_reports_modem_failure():
     modem.send_dtmf = lambda digits: False  # type: ignore[attr-defined]
     service = make_service(modem, audio_mode="nmea")
     service.session._active = True
+    record = SpyCallRecord()
+    service.session._record = record  # type: ignore[assignment]
 
-    ok, err = service.send_dtmf("1")
+    ok, err = service.send_dtmf("73#")
+
     assert not ok and "按键发送失败" in (err or "")
+    assert record.events == [
+        ("dtmf", {"count": 3, "mode": "qvts", "result": "failure"})
+    ]
+    assert "73#" not in str(record.events)
+
+
+def test_service_send_dtmf_mode_resolution_failure_is_redacted(monkeypatch):
+    modem = FakeModem()
+    service = make_service(modem, audio_mode="uac")
+    service.session._active = True
+    record = SpyCallRecord()
+    service.session._record = record  # type: ignore[assignment]
+
+    def fail_config_read(_key: str) -> str:
+        raise RuntimeError("config unavailable")
+
+    monkeypatch.setattr("agentcall.call_agent.config.get_str", fail_config_read)
+
+    ok, err = service.send_dtmf("73#")
+
+    assert not ok and "按键发送失败" in (err or "")
+    assert record.events == [
+        ("dtmf", {"count": 3, "mode": "unknown", "result": "failure"})
+    ]
+    assert "73#" not in str(record.events)
 
 
 # ---- 远程网页拨号会话 ----

--- a/tests/unit/test_call_tools.py
+++ b/tests/unit/test_call_tools.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 
 from fakes import FakeModem
 
@@ -219,18 +220,41 @@ def test_hangup_triggers_schedule_callback():
 
 # ---- send_dtmf ----
 
-def test_send_dtmf_dispatches_to_modem_and_logs_record():
+def test_send_dtmf_dispatch_redacts_logs_result_and_audit(caplog):
     modem = FakeModem()
     sent: list[str] = []
     modem.send_dtmf = lambda digits: sent.append(digits) or True  # type: ignore[attr-defined]
     record = SpyRecord()
     tools, _, _ = make_tools(modem=modem, record=record)
 
-    result = tools._send_dtmf({"digits": "103#"})
+    with caplog.at_level(logging.INFO):
+        result = tools.register().dispatch("send_dtmf", {"digits": "103#"})
 
     assert result["success"] is True
+    assert result["count"] == 4
+    assert result["mode"] == "qvts"
+    assert "digits" not in result
+    assert "103#" not in result["message"]
+    assert "103#" not in caplog.text
+    assert "count=4" in caplog.text
+    assert "mode=qvts" in caplog.text
+    assert "result=success" in caplog.text
     assert sent == ["103#"]
-    assert record.events == [("dtmf", {"digits": "103#", "mode": "qvts"})]  # 审计日志
+    assert record.events == [
+        ("dtmf", {"count": 4, "mode": "qvts", "result": "success"})
+    ]  # 审计日志
+
+
+def test_send_dtmf_audit_does_not_persist_plaintext_digits():
+    record = SpyRecord()
+    tools, _, _ = make_tools(record=record)
+
+    tools._send_dtmf({"digits": "103#"})
+
+    _event_type, fields = record.events[0]
+    assert fields["count"] == 4
+    assert "digits" not in fields
+    assert "103#" not in repr(fields)
 
 
 def test_send_dtmf_uses_injected_session_sender_and_logs_mode():
@@ -246,7 +270,9 @@ def test_send_dtmf_uses_injected_session_sender_and_logs_mode():
     assert result["success"] is True
     assert sent == ["9"]
     assert modem.calls == []
-    assert record.events == [("dtmf", {"digits": "9", "mode": "inband"})]
+    assert record.events == [
+        ("dtmf", {"count": 1, "mode": "inband", "result": "success"})
+    ]
 
 
 def test_send_dtmf_rejects_empty_digits():
@@ -255,14 +281,27 @@ def test_send_dtmf_rejects_empty_digits():
     assert modem.calls == []
 
 
-def test_send_dtmf_exception_reported_as_failure():
+def test_send_dtmf_failure_dispatch_redacts_logs_result_and_audit(caplog):
     modem = FakeModem()
     modem.send_dtmf = lambda digits: (_ for _ in ()).throw(RuntimeError("AT 超时"))  # type: ignore[attr-defined]
-    tools, _, _ = make_tools(modem=modem)
+    record = SpyRecord()
+    tools, _, _ = make_tools(modem=modem, record=record)
 
-    result = tools._send_dtmf({"digits": "1"})
+    with caplog.at_level(logging.INFO):
+        result = tools.register().dispatch("send_dtmf", {"digits": "73#"})
+
     assert result["success"] is False
-    assert "AT 超时" in result["message"]
+    assert result["count"] == 3
+    assert result["mode"] == "qvts"
+    assert "digits" not in result
+    assert "73#" not in result["message"]
+    assert "73#" not in caplog.text
+    assert "count=3" in caplog.text
+    assert "mode=qvts" in caplog.text
+    assert "result=failure" in caplog.text
+    assert record.events == [
+        ("dtmf", {"count": 3, "mode": "qvts", "result": "failure"})
+    ]
 
 
 # ---- query_verification_code ----

--- a/tests/unit/test_modem_parsing.py
+++ b/tests/unit/test_modem_parsing.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import threading
 import time
 
@@ -199,14 +200,19 @@ def test_no_carrier_triggers_hangup():
 # ---- DTMF 发送 ----
 
 
-def test_send_dtmf_sends_each_digit(monkeypatch):
+def test_send_dtmf_sends_each_digit_without_logging_plaintext(monkeypatch, caplog):
     modem = make_modem()
     sent_cmds = []
     monkeypatch.setattr(modem, "_send", lambda cmd: sent_cmds.append(cmd) or "OK")
     monkeypatch.setattr("agentcall.modem.time.sleep", lambda s: None)
 
-    assert modem.send_dtmf("1a#") is True  # 小写自动转大写
+    with caplog.at_level(logging.INFO):
+        assert modem.send_dtmf("1a#") is True  # 小写自动转大写
+
     assert sent_cmds == ['AT+QVTS="1"', 'AT+QVTS="A"', 'AT+QVTS="#"']
+    assert "1A#" not in caplog.text
+    assert "count=3" in caplog.text
+    assert "result=success" in caplog.text
 
 
 def test_send_dtmf_falls_back_to_vts(monkeypatch):
@@ -224,11 +230,28 @@ def test_send_dtmf_falls_back_to_vts(monkeypatch):
     assert sent_cmds == ['AT+QVTS="5"', 'AT+VTS="5"']
 
 
-def test_send_dtmf_rejects_invalid(monkeypatch):
+def test_send_dtmf_rejects_invalid_without_logging_plaintext(monkeypatch, caplog):
     modem = make_modem()
     monkeypatch.setattr(modem, "_send", lambda cmd: "OK")
-    assert modem.send_dtmf("12x") is False
+    with caplog.at_level(logging.WARNING):
+        assert modem.send_dtmf("12x") is False
+
     assert modem.send_dtmf("") is False
+    assert "12X" not in caplog.text
+    assert "count=3" in caplog.text
+    assert "result=failure" in caplog.text
+
+
+def test_send_dtmf_modem_failure_does_not_log_failed_digit(monkeypatch, caplog):
+    modem = make_modem()
+    monkeypatch.setattr(modem, "_send", lambda cmd: "ERROR")
+
+    with caplog.at_level(logging.WARNING):
+        assert modem.send_dtmf("#") is False
+
+    assert "#" not in caplog.text
+    assert "count=1" in caplog.text
+    assert "result=failure" in caplog.text
 
 
 # ---- hangup 原子性：指令序列不被并发 _send 插队 ----

--- a/tests/unit/test_openai_agent.py
+++ b/tests/unit/test_openai_agent.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import logging
 
 import pytest
 
@@ -405,6 +406,26 @@ def test_tool_call_round_trip(monkeypatch):
     # function_call_output 之后必须跟 response.create 让模型接着说
     idx = ws.sent.index(outputs[0])
     assert ws.sent[idx + 1] == {"type": "response.create"}
+
+
+def test_invalid_tool_arguments_log_omits_raw_payload(caplog):
+    agent = _make_agent()
+    ws = _FakeWs()
+    agent._ws = ws
+    arguments = '{"digits":"73#"'
+
+    with caplog.at_level(logging.WARNING):
+        asyncio.run(
+            agent._dispatch_tool_call(
+                "send_dtmf", "call-invalid-json", arguments, ws
+            )
+        )
+
+    assert "73#" not in caplog.text
+    assert arguments not in caplog.text
+    assert "send_dtmf" in caplog.text
+    assert f"arguments_length={len(arguments)}" in caplog.text
+    assert "error_type=JSONDecodeError" in caplog.text
 
 
 def test_terminal_tool_skips_response_create(monkeypatch):

--- a/tests/unit/test_qwen_agent.py
+++ b/tests/unit/test_qwen_agent.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import logging
 import threading
 import time
 from queue import Empty
@@ -410,6 +411,27 @@ def test_manual_response_control_tool_response_blocks_overlap(monkeypatch):
             "response": {"id": "tool-response"},
         })
         assert _wait_until(lambda: len(conv.responses) == 2)
+    finally:
+        asyncio.run(agent.stop())
+
+
+def test_invalid_tool_arguments_log_omits_raw_payload(monkeypatch, caplog):
+    fake_cls = _make_fake_conversation_cls()
+    agent = _start_agent(monkeypatch, fake_cls)
+    conversation = fake_cls.instances[-1]
+    arguments = '{"digits":"73#"'
+    try:
+        with caplog.at_level(logging.WARNING):
+            agent._dispatch_tool_call(
+                "send_dtmf", "call-invalid-json", arguments
+            )
+            assert _wait_until(lambda: len(conversation.items) == 1)
+
+        assert "73#" not in caplog.text
+        assert arguments not in caplog.text
+        assert "send_dtmf" in caplog.text
+        assert f"arguments_length={len(arguments)}" in caplog.text
+        assert "error_type=JSONDecodeError" in caplog.text
     finally:
         asyncio.run(agent.stop())
 

--- a/tests/unit/test_remote_dialer.py
+++ b/tests/unit/test_remote_dialer.py
@@ -251,7 +251,7 @@ async def _wait_for(predicate, timeout: float = 1.0) -> None:
     raise AssertionError("condition was not met before timeout")
 
 
-def _runtime() -> RemoteDialerRuntimeConfig:
+def _runtime(*, dtmf_mode: str = "inband") -> RemoteDialerRuntimeConfig:
     return RemoteDialerRuntimeConfig(
         audio_mode="uac",
         audio_keyword="Interface",
@@ -261,7 +261,7 @@ def _runtime() -> RemoteDialerRuntimeConfig:
         disconnect_grace_seconds=0.05,
         outbound_max_seconds=2.0,
         connect_timeout_seconds=0.2,
-        dtmf_mode="inband",
+        dtmf_mode=dtmf_mode,
     )
 
 
@@ -271,13 +271,14 @@ def _coordinator(
     bridge: FakeBridge,
     *,
     call_logger: CallLogger | None = None,
+    dtmf_mode: str = "inband",
 ) -> RemoteWebDialerCoordinator:
     return RemoteWebDialerCoordinator(
         session_id="session-test",
         expires_at=time.time() + 60,
         modem=modem,  # type: ignore[arg-type]
         endpoint=endpoint,
-        runtime=_runtime(),
+        runtime=_runtime(dtmf_mode=dtmf_mode),
         bridge_factory=lambda **_kwargs: bridge,  # type: ignore[arg-type]
         call_logger=call_logger,
         reserve_line=lambda _owner: None,
@@ -353,6 +354,50 @@ def test_full_duplex_audio_recording_and_dtmf(tmp_path: Path) -> None:
         assert meta["source"] == "remote_web_dialer"
         assert meta["uplink_bytes"] == 320
         assert meta["downlink_bytes"] > 320  # browser speech plus in-band DTMF
+        events_path = meta_path.with_name("events.jsonl")
+        events = [json.loads(line) for line in events_path.read_text(encoding="utf-8").splitlines()]
+        [dtmf_event] = [event for event in events if event["type"] == "dtmf"]
+        assert dtmf_event["count"] == 1
+        assert dtmf_event["mode"] == "inband"
+        assert dtmf_event["result"] == "success"
+        assert "digits" not in dtmf_event
+
+    asyncio.run(run())
+
+
+def test_failed_remote_dtmf_audit_does_not_contain_plaintext() -> None:
+    class SpyRecord:
+        def __init__(self) -> None:
+            self.events: list[tuple[str, dict[str, Any]]] = []
+
+        def log_event(self, type: str, **fields: Any) -> None:  # noqa: A002
+            self.events.append((type, fields))
+
+    async def run() -> None:
+        endpoint = FakeRemoteEndpoint()
+        modem = FakeModem()
+        modem.send_dtmf = lambda _digits: False  # type: ignore[method-assign]
+        bridge = FakeBridge()
+        coordinator = _coordinator(endpoint, modem, bridge, dtmf_mode="qvts")
+        record = SpyRecord()
+        coordinator.call_active.set()
+        coordinator._bridge = bridge
+        coordinator._record = record  # type: ignore[assignment]
+
+        await coordinator._handle_dtmf({"digits": "73#"})
+
+        assert record.events == [
+            (
+                "dtmf",
+                {
+                    "count": 3,
+                    "mode": "qvts",
+                    "result": "failure",
+                    "source": "remote_web_dialer",
+                },
+            )
+        ]
+        assert "73#" not in str(record.events)
 
     asyncio.run(run())
 


### PR DESCRIPTION
> Refs #53（#48 威胁建模 G-03）。DTMF 常是银行/语音信箱 PIN，明文进日志是敏感数据泄露面。

## 三轮独立 review 逐层揪出 4 条泄露路径，全闭合
1. 审计事件（call_agent/call_tools/remote_dialer 的 `log_event("dtmf", digits=...)`）→ 改记 count/mode/result
2. AI 工具调度（agents/tools + call_tools 返回值/文案）→ 不落明文数字
3. modem 层 QVTS/VTS 日志（非法输入/模组失败/成功三处）→ 只记计数与结果
4. provider 层（openai/qwen）工具参数 JSON 解析失败日志 → 不再记原始 arguments，**通用对所有工具生效**（不特判 dtmf）

全仓复扫确认无第 5 条持久化泄露路径。

## 验证
- [x] 全量 pytest **731 passed** / ruff / mypy 绿（维护者本机；新增 caplog 日志无明文断言能抓回归）
- [x] 独立 review 三轮：BLOCK → BLOCK → **APPROVE 可合入**
- [x] DTMF 实际发送逻辑/时序/带内音频/QVTS 回退/返回模型语义均未改
- [ ] CI 绿
- [ ] merge 需 owner 批准

🤖 Generated with [Claude Code](https://claude.com/claude-code)