### PR TITLE
fix: recover local call monitoring after audio interruption

### DIFF
--- a/src/agentcall/config.py
+++ b/src/agentcall/config.py
@@ -247,12 +247,24 @@ CONFIG_SPECS: tuple[ConfigSpec, ...] = (
     ConfigSpec("SUMMARY_TIMEOUT", "摘要超时（秒）", "float", "30",
                editable=False, hidden=True),
     # ---- 本地监听 ----
-    ConfigSpec("MONITOR_AI_PLAYBACK", "本地监听 AI 语音", "bool", "false"),
+    ConfigSpec(
+        "MONITOR_AI_PLAYBACK", "本地监听 AI 语音", "bool", "false",
+        requires_restart=True,
+    ),
     # 默认留空 = 跟随系统默认输出设备（可移植；填设备名则按名匹配）。
-    ConfigSpec("MONITOR_OUTPUT_DEVICE", "监听输出设备", "str", ""),
-    ConfigSpec("MONITOR_AI_GAIN", "监听增益（AI 下行）", "float", "1.0"),
+    ConfigSpec(
+        "MONITOR_OUTPUT_DEVICE", "监听输出设备", "str", "",
+        requires_restart=True,
+    ),
+    ConfigSpec(
+        "MONITOR_AI_GAIN", "监听增益（AI 下行）", "float", "1.0",
+        requires_restart=True,
+    ),
     # 电话上行是窄带信号且电平偏低，监听需大幅放大（真机调到 15 倍才够听清）。
-    ConfigSpec("MONITOR_UPLINK_GAIN", "监听增益（对方上行）", "float", "8.0"),
+    ConfigSpec(
+        "MONITOR_UPLINK_GAIN", "监听增益（对方上行）", "float", "8.0",
+        requires_restart=True,
+    ),
     # ---- 白名单与节流 ----
     ConfigSpec("DIAL_WHITELIST", "外呼白名单", "str", ""),
     ConfigSpec("DIAL_INTERVAL_SECONDS", "连续拨号间隔（秒）", "float", "5.0"),

--- a/src/agentcall/web/static/index.html
+++ b/src/agentcall/web/static/index.html
@@ -1739,13 +1739,21 @@ async function loadMeta() {
 
 /* ========= 实时旁听：Web Audio 播放下行 PCM（走浏览器→系统音频，绕开 native）========= */
 // 下行(AI)与上行(对方)各一条播放时间线，按帧首字节的方向标记分流，两路同时出声。
-let audioWs = null, audioCtx = null;
+let audioWs = null, audioCtx = null, audioResumePending = false;
 const listenRate = {0: 24000, 1: 8000};   // 0=下行 1=上行
 const listenNextAt = {0: 0, 1: 0};
-function toggleListen() {
-  if (audioWs) { stopListen(); return; }
+async function ensureListenAudioRunning() {
+  if (!audioCtx) return false;
+  if (audioCtx.state === "running") return true;
+  try { await audioCtx.resume(); }
+  catch (e) { console.warn("[listen] AudioContext 恢复失败", e); return false; }
+  return audioCtx.state === "running";
+}
+async function toggleListen() {
+  if (audioWs || audioCtx) { stopListen(); return; }
   try { audioCtx = new (window.AudioContext || window.webkitAudioContext)(); }
   catch (e) { console.warn("[listen] AudioContext 不可用", e); return; }
+  if (!(await ensureListenAudioRunning())) { stopListen(); return; }
   listenNextAt[0] = 0; listenNextAt[1] = 0;
   const proto = location.protocol === "https:" ? "wss" : "ws";
   audioWs = new WebSocket(`${proto}://${location.host}/ws/audio`);
@@ -1760,11 +1768,31 @@ function toggleListen() {
       return;
     }
     const kind = new Uint8Array(e.data, 0, 1)[0];        // 首字节：方向
-    playPcm(new Int16Array(e.data.slice(1)), kind);      // 其余：s16le PCM
+    const int16 = new Int16Array(e.data.slice(1));       // 其余：s16le PCM
+    if (!audioCtx || audioCtx.state !== "running") {
+      void resumeAndPlayPcm(int16, kind);
+      return;
+    }
+    playPcm(int16, kind);
   };
   audioWs.onclose = () => { if (audioWs) stopListen(); };
   const btn = $("listenBtn");
   btn.classList.add("on"); btn.textContent = t("listen_on");
+}
+async function resumeAndPlayPcm(int16, kind) {
+  if (audioResumePending) return;
+  audioResumePending = true;
+  const context = audioCtx;
+  try {
+    if (!(await ensureListenAudioRunning()) || audioCtx !== context) {
+      if (audioCtx === context) stopListen();
+      return;
+    }
+    listenNextAt[kind] = 0;
+    playPcm(int16, kind);
+  } finally {
+    audioResumePending = false;
+  }
 }
 function playPcm(int16, kind) {
   if (!audioCtx || !int16.length) return;
@@ -1781,6 +1809,7 @@ function playPcm(int16, kind) {
   listenNextAt[kind] += buf.duration;
 }
 function stopListen() {
+  audioResumePending = false;
   if (audioWs) { try { audioWs.onclose = null; audioWs.close(); } catch (_) {} audioWs = null; }
   if (audioCtx) { try { audioCtx.close(); } catch (_) {} audioCtx = null; }
   const btn = $("listenBtn");

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -840,6 +840,17 @@ def test_voice_specs_are_selects_with_default_in_choices():
     }
 
 
+def test_local_monitor_settings_require_service_restart():
+    """监听播放器只在服务启动时构造，面板保存后必须触发重启。"""
+    for key in (
+        "MONITOR_AI_PLAYBACK",
+        "MONITOR_OUTPUT_DEVICE",
+        "MONITOR_AI_GAIN",
+        "MONITOR_UPLINK_GAIN",
+    ):
+        assert get_spec(key).requires_restart, key
+
+
 def test_is_loopback_host():
     from agentcall.config import is_loopback_host
 

--- a/tests/unit/test_web_api.py
+++ b/tests/unit/test_web_api.py
@@ -421,6 +421,7 @@ def test_config_post_roundtrip(monkeypatch, tmp_path):
     monkeypatch.setenv("QWEN_VOICE", "Raymond")
     monkeypatch.setenv("AGENT_PROVIDER", "qwen")
     monkeypatch.setenv("RECORDING_ENABLED", "true")
+    monkeypatch.setenv("MONITOR_AI_PLAYBACK", "false")
 
     app = make_app(FakeService())
 
@@ -431,6 +432,7 @@ def test_config_post_roundtrip(monkeypatch, tmp_path):
                 "QWEN_VOICE": "Ethan",
                 "AGENT_PROVIDER": "doubao",
                 "RECORDING_ENABLED": False,  # JSON bool 应被宽容转成 "false"
+                "MONITOR_AI_PLAYBACK": True,
             },
         )
         assert resp.status == 200
@@ -438,13 +440,19 @@ def test_config_post_roundtrip(monkeypatch, tmp_path):
 
     data = api(app, fn)
     assert data["ok"] is True
-    assert data["updated"] == ["QWEN_VOICE", "AGENT_PROVIDER", "RECORDING_ENABLED"]
-    assert data["requires_restart"] == ["AGENT_PROVIDER"]
+    assert data["updated"] == [
+        "QWEN_VOICE",
+        "AGENT_PROVIDER",
+        "RECORDING_ENABLED",
+        "MONITOR_AI_PLAYBACK",
+    ]
+    assert data["requires_restart"] == ["AGENT_PROVIDER", "MONITOR_AI_PLAYBACK"]
 
     text = env_file.read_text(encoding="utf-8")
     assert "QWEN_VOICE=Ethan" in text
     assert "AGENT_PROVIDER=doubao" in text
     assert "RECORDING_ENABLED=false" in text
+    assert "MONITOR_AI_PLAYBACK=true" in text
     assert os.environ["QWEN_VOICE"] == "Ethan"
 
 

--- a/tests/unit/test_web_static.py
+++ b/tests/unit/test_web_static.py
@@ -86,6 +86,17 @@ def test_websocket_reconnect_clears_stale_call_and_recording_state():
     assert 'setCall("idle", "");' in text
 
 
+def test_dashboard_listener_recovers_suspended_web_audio():
+    """WebKit 打断 AudioContext 后，旁听要恢复而不是保持“旁听中”但静音。"""
+    text = INDEX.read_text(encoding="utf-8")
+
+    assert "async function ensureListenAudioRunning()" in text
+    assert 'if (audioCtx.state === "running") return true;' in text
+    assert "await audioCtx.resume();" in text
+    assert "if (!(await ensureListenAudioRunning()))" in text
+    assert "void resumeAndPlayPcm(int16, kind);" in text
+
+
 def test_settings_expose_sms_email_forwarding_with_bilingual_privacy_notice():
     text = INDEX.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

- resume WebAudio when WebKit suspends or interrupts the dashboard listening context
- stop showing a false listening state when audio recovery fails
- mark native monitor enable/device/gain settings as requiring service restart
- keep local monitoring opt-in

## Evidence

- live incident: call media, recording, and transcription remained valid while Mac playback was silent
- runtime recovery: enabled native 24 kHz downlink and 8 kHz uplink monitors; next inbound call was audible on the Mac
- regression tests cover AudioContext recovery hooks and configuration restart signaling

## Verification

- `pytest -q`: 733 passed, 3 skipped
- `ruff check .`: passed
- `mypy src`: passed
- inline dashboard JavaScript: `node --check` passed

Closes #76