### PR TITLE
fix: 修远程外呼真人号两个 bug——卡「拨号中」(#74) + 「接通即掉」(#75)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -131,6 +131,9 @@ DIAL_WHITELIST=
 DIAL_INTERVAL_SECONDS=5.0
 # 短信发送频控（AI 工具与 Web 接口共用，默认每小时 10 条；0=不限）
 SMS_RATE_LIMIT_PER_HOUR=10
+# 短信目标限制：默认只能回复「已联系过的号码」（来过电/发过短信/已接通外呼）。
+# 开发期总开关：置 true 放行发给任意号码（仅本机开发测试用，默认关，勿在生产开启）。
+SMS_ALLOW_ANY_TARGET=false
 # 收件短信进 app 后删 SIM 上那条，防 SIM 存储满收不到新短信（默认开）
 SMS_DELETE_AFTER_INGEST=true
 # 收到新短信后转发到邮箱（默认关闭）。开启后短信正文会发送到下面的收件邮箱。

--- a/src/agentcall/audio_bridge.py
+++ b/src/agentcall/audio_bridge.py
@@ -15,6 +15,7 @@ import serial
 
 # 导入模块而非 from-import 常量：让测试能 monkeypatch platforms.IS_MACOS。
 from . import platforms
+from .pcm_stats import PcmFlowStats
 
 logger = logging.getLogger(__name__)
 
@@ -336,6 +337,10 @@ class FfmpegAudioBridge:
         self._tx_lock = threading.Lock()
         self._writer_thread: threading.Thread | None = None
         self._running = False
+        # 上行第三段观测：真实写入 AS（audiotoolbox 播放）的帧统计，
+        # 只统计非静音 payload；补零静音单独计次。仅写线程内使用。
+        self._write_stats = PcmFlowStats("uplink3_as_write")
+        self._silence_writes = 0
 
     @staticmethod
     def _find_avfoundation_input(keyword: str) -> int | None:
@@ -459,26 +464,43 @@ class FfmpegAudioBridge:
                 time.sleep(0.5)
                 next_write_at = time.monotonic()
                 continue
-            payload = self._next_write_payload(silence)
+            payload, real_bytes = self._next_write_payload(silence)
             if self._play and self._play.stdin:
                 try:
                     self._play.stdin.write(payload)
                     self._play.stdin.flush()
                 except (BrokenPipeError, ValueError):
                     continue  # 进程已退出，下一轮由上面的 poll() 统一处理重启
+                # 只统计写成功的：真实 payload 记帧/峰值，纯静音只计次。
+                if real_bytes:
+                    self._write_stats.add(payload[:real_bytes])
+                else:
+                    self._silence_writes += 1
+                if self._write_stats.maybe_log(
+                    silence_writes=self._silence_writes,
+                    play_alive=self._play.poll() is None,
+                    pending=self.pending_output_bytes(),
+                ):
+                    self._silence_writes = 0
             next_write_at += NMEA_WRITE_INTERVAL_SECONDS
 
-    def _next_write_payload(self, silence: bytes) -> bytes:
+    def _next_write_payload(self, silence: bytes) -> tuple[bytes, int]:
+        """取下一块待写数据，返回 (payload, 其中真实数据的字节数)。
+
+        真实字节数供写线程区分「转发的上行 PCM」与「保持时钟的补零静音」——
+        观测统计只对前者记帧/峰值。
+        """
         with self._tx_lock:
             if len(self._tx_buffer) >= NMEA_WRITE_SIZE:
                 payload = bytes(self._tx_buffer[:NMEA_WRITE_SIZE])
                 del self._tx_buffer[:NMEA_WRITE_SIZE]
-                return payload
+                return payload, len(payload)
             if self._tx_buffer:
                 payload = bytes(self._tx_buffer)
                 self._tx_buffer.clear()
-                return payload + silence[: NMEA_WRITE_SIZE - len(payload)]
-        return silence
+                padded = payload + silence[: NMEA_WRITE_SIZE - len(payload)]
+                return padded, len(payload)
+        return silence, 0
 
     @staticmethod
     def modem_to_agent(pcm_8k: bytes, agent_rate: int) -> bytes:

--- a/src/agentcall/call_agent.py
+++ b/src/agentcall/call_agent.py
@@ -601,7 +601,11 @@ class CallSession:
         与落盘的短信/来电记录一起判定。
         """
         return is_reply_target_allowed(
-            number, self.hub, self.call_logger, extra_allowed=self.current_caller
+            number,
+            self.hub,
+            self.call_logger,
+            extra_allowed=self.current_caller,
+            allow_any=config.get_bool("SMS_ALLOW_ANY_TARGET"),
         )
 
     def _build_agent_instructions(self, direction: str) -> str:

--- a/src/agentcall/config.py
+++ b/src/agentcall/config.py
@@ -284,6 +284,8 @@ CONFIG_SPECS: tuple[ConfigSpec, ...] = (
                requires_restart=True),
     # 发短信目标限制改为「只能回复已联系过的号码」(见 contacts.py),
     # 不再用静态白名单,故移除原 SMS_WHITELIST 配置项。
+    # 开发期总开关:置 true 时放行给任意号码发短信(仅本机开发测试用,默认关)。
+    ConfigSpec("SMS_ALLOW_ANY_TARGET", "短信允许发给任意号码(开发用)", "bool", "false"),
     # ---- 连接管理 ----
     ConfigSpec("QWEN_PREWARM", "Qwen 连接预热", "bool", "true"),
     ConfigSpec("QWEN_RECONNECT_MAX", "Qwen 最大重连次数", "int", "2"),

--- a/src/agentcall/contacts.py
+++ b/src/agentcall/contacts.py
@@ -84,18 +84,22 @@ def is_reply_target_allowed(
     call_logger: "CallLogger | None",
     *,
     extra_allowed: str | None = None,
+    allow_any: bool = False,
 ) -> bool:
     """判断能否给 ``number`` 发短信。
 
     放行条件(满足其一):
+    - ``allow_any`` 为真(开发期总开关 ``SMS_ALLOW_ANY_TARGET``,放行任意非空号码);
     - 等于 ``extra_allowed``(当前通话对端,通话中可直接回短信);
     - 是收到过短信的号码、任一来电方,或已接通的外呼号码。
 
-    空号码一律拒绝。
+    空号码一律拒绝(``allow_any`` 也不放行空号码)。
     """
     target = _norm(number)
     if not target:
         return False
+    if allow_any:
+        return True
     if extra_allowed and _norm(extra_allowed) == target:
         return True
     return target in known_contact_numbers(hub, call_logger)

--- a/src/agentcall/livekit_media.py
+++ b/src/agentcall/livekit_media.py
@@ -7,6 +7,7 @@ import json
 import logging
 from typing import Any
 
+from .pcm_stats import PcmFlowStats
 from .remote_dialer import (
     REMOTE_AUDIO_RATE,
     REMOTE_CONTROL_TOPIC,
@@ -82,6 +83,10 @@ class LiveKitRemoteMediaEndpoint:
         self._browser_connected = False
         self._media_ready = False
         self._closed = False
+        # 上行第一段观测：浏览器（手机）→ LiveKit → Edge 的入站帧统计。
+        # 打点由 take_browser_audio（remote pump 每 10ms 调）驱动，
+        # 因此 LiveKit 一帧未推时也会按期打出 frames=0。
+        self._browser_in_stats = PcmFlowStats("uplink1_lk_in")
 
     @property
     def media_ready(self) -> bool:
@@ -251,6 +256,10 @@ class LiveKitRemoteMediaEndpoint:
                 chunks.append(self._browser_audio.get_nowait())
             except asyncio.QueueEmpty:
                 break
+        self._browser_in_stats.maybe_log(
+            queued=self._browser_audio.qsize(),
+            media_ready=self._media_ready,
+        )
         return chunks
 
     def push_modem_audio(self, pcm: bytes) -> None:
@@ -284,6 +293,7 @@ class LiveKitRemoteMediaEndpoint:
             async for event in stream:
                 pcm = bytes(event.frame.data)
                 if pcm:
+                    self._browser_in_stats.add(pcm)
                     _put_latest(self._browser_audio, pcm)
         except asyncio.CancelledError:
             raise

--- a/src/agentcall/pcm_stats.py
+++ b/src/agentcall/pcm_stats.py
@@ -1,0 +1,85 @@
+"""音频链路周期统计（隐私安全：只记帧数/字节/峰值等数字，不落任何 PCM 内容）。
+
+用途：二分「链路已建立但无声」类故障——上行各段（LiveKit 入站 → Edge 泵取走 →
+ffmpeg AS 写入）各挂一个实例，对照各段的 5s 统计日志即可定位断流 / 全零
+发生在哪一段，而不必录下音频内容。
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from array import array
+from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+
+class PcmFlowStats:
+    """按固定窗口聚合一段 PCM 流的 frames/bytes/peak 并输出一行日志。
+
+    - ``add()`` 每帧调用，峰值按 s16le 采样绝对值取最大——只留数字，不留内容；
+    - ``maybe_log()`` 供高频循环（如 10ms 泵）反复调用，窗口未到期是 no-op；
+      到期即输出并复位。**即使整窗一帧未到（add 从未被调）也会按期打出
+      frames=0**——这正是断流定位需要的信号。
+    - 无锁，跨线程不可共享。同一 event loop 内多个 task 同步访问是安全的
+      （所有方法内部无 await，不会交错）——uplink1 即 add 与 maybe_log
+      分属两个 task 的用法。
+    """
+
+    def __init__(
+        self,
+        label: str,
+        interval_seconds: float = 5.0,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.label = label
+        self.interval_seconds = interval_seconds
+        self._clock = clock
+        self._window_started = clock()
+        self._frames = 0
+        self._bytes = 0
+        self._peak = 0
+
+    def add(self, pcm: bytes) -> None:
+        self._frames += 1
+        self._bytes += len(pcm)
+        usable = len(pcm) - (len(pcm) % 2)
+        if usable:
+            samples = array("h", pcm[:usable])
+            peak = max(max(samples), -min(samples))
+            if peak > self._peak:
+                self._peak = peak
+
+    def due(self) -> bool:
+        """窗口是否已到期。取 extra 状态有成本（如拿锁）时先用它判断。"""
+        return self._clock() - self._window_started >= self.interval_seconds
+
+    def maybe_log(self, **extra: object) -> bool:
+        """窗口到期则输出统计并复位，返回 True；未到期返回 False。
+
+        ``extra`` 里的键值原样附在日志尾部（如 queued/pending/play_alive），
+        供调用方带上队列深度等瞬时状态。
+        """
+        now = self._clock()
+        elapsed = now - self._window_started
+        if elapsed < self.interval_seconds:
+            return False
+        detail = "".join(f" {key}={value}" for key, value in extra.items())
+        logger.info(
+            "[audio-stats] %s %.1fs: frames=%d bytes=%d peak=%d%s",
+            self.label,
+            elapsed,
+            self._frames,
+            self._bytes,
+            self._peak,
+            detail,
+        )
+        self._window_started = now
+        self._frames = 0
+        self._bytes = 0
+        self._peak = 0
+        return True
+
+
+__all__ = ["PcmFlowStats"]

--- a/src/agentcall/remote_dialer.py
+++ b/src/agentcall/remote_dialer.py
@@ -251,6 +251,9 @@ class RemoteWebDialerCoordinator:
         self.edge_ready = threading.Event()
         self.finished = threading.Event()
         self.call_active = threading.Event()
+        # call_active 在 ATD 前即置位（振铃阶段）；_call_connected 仅在模组物理
+        # 接通后置位，用于区分「振铃期」与「已接通」两种断线守护策略（#75）。
+        self._call_connected = threading.Event()
         self.last_error: str | None = None
         self._stop_requested = threading.Event()
         self._stop_reason = "edge_shutdown"
@@ -297,7 +300,8 @@ class RemoteWebDialerCoordinator:
 
     async def run(self) -> None:
         media_was_ready = False
-        media_lost_at: float | None = None
+        disconnect_since: float | None = None
+        prev_connected_phase = False
         try:
             await self.endpoint.connect()
             self.edge_ready.set()
@@ -312,20 +316,45 @@ class RemoteWebDialerCoordinator:
 
                 if self.endpoint.media_ready and not media_was_ready:
                     media_was_ready = True
-                    media_lost_at = None
                     await self._send_status("media_ready")
                 elif not self.endpoint.media_ready and media_was_ready:
                     media_was_ready = False
-                    media_lost_at = time.monotonic()
 
-                if self.call_active.is_set() and not self.endpoint.media_ready:
-                    if media_lost_at is None:
-                        media_lost_at = time.monotonic()
-                    if (
-                        time.monotonic() - media_lost_at
-                        >= self.runtime.disconnect_grace_seconds
-                    ):
-                        self.request_call_stop("media_disconnected")
+                # phase-aware 断线守护（#75）：
+                # - 振铃期（未物理接通）：只有**控制连接**真断（browser_connected
+                #   =False）才按 grace 挂断；音轨暂时 mute/重协商（media_ready=False
+                #   但参与者仍在）不中断振铃，否则长振铃真人号会被误挂（接通即掉）。
+                # - 已接通：媒体轨长期丢失才按 grace 安全收尾。
+                if self.call_active.is_set():
+                    connected_phase = self._call_connected.is_set()
+                    if connected_phase != prev_connected_phase:
+                        # 阶段切换（振铃→接通）：判据身份变化，重置计时——
+                        # 接通后应享有完整媒体 grace，不沿用振铃期的控制断计时
+                        # （否则接通瞬间残留计时到点会立即误挂，仍表现为「接通即掉」）。
+                        disconnect_since = None
+                        prev_connected_phase = connected_phase
+                    if connected_phase:
+                        disconnected = not self.endpoint.media_ready
+                        stop_reason, phase = "media_disconnected", "connected"
+                    else:
+                        disconnected = not self.endpoint.browser_connected
+                        stop_reason, phase = "control_disconnected", "ringing"
+                    if disconnected:
+                        if disconnect_since is None:
+                            disconnect_since = time.monotonic()
+                        elif (
+                            time.monotonic() - disconnect_since
+                            >= self.runtime.disconnect_grace_seconds
+                        ):
+                            logger.info(
+                                "远程通话本端 ATH: reason=%s phase=%s", stop_reason, phase
+                            )
+                            self.request_call_stop(stop_reason)
+                    else:
+                        disconnect_since = None
+                else:
+                    disconnect_since = None
+                    prev_connected_phase = False
 
                 command: dict[str, Any] | None
                 try:
@@ -494,9 +523,13 @@ class RemoteWebDialerCoordinator:
                 record.log_event("dialing", source=REMOTE_CALL_SOURCE)
 
             deadline = time.monotonic() + self.runtime.connect_timeout_seconds
-            while time.monotonic() < deadline and not self._call_stop_requested.is_set():
+            while time.monotonic() < deadline:
+                # 先判接通、再判 stop：避免接通与 grace 同 tick 时 stop 抢先，
+                # 把已接起的电话误判为 not_connected（#75）。
                 if self.modem.is_call_connected():
                     connected = True
+                    break
+                if self._call_stop_requested.is_set():
                     break
                 await asyncio.sleep(0.05)
             if not connected:
@@ -506,9 +539,14 @@ class RemoteWebDialerCoordinator:
                     if self._call_stop_requested.is_set()
                     else "not_connected"
                 )
+                logger.info(
+                    "远程外呼未接通即收尾: reason=%s phase=ringing", finish_reason
+                )
                 await self._send_status("ended", reason=finish_reason)
                 return
 
+            # 物理接通：此后断线守护改用「媒体轨」判据（振铃期用「控制连接」）。
+            self._call_connected.set()
             self.modem.initialize_for_voice(self.runtime.audio_mode)
             bridge = self.bridge_factory(
                 mode=self.runtime.audio_mode,
@@ -593,6 +631,7 @@ class RemoteWebDialerCoordinator:
                 self._line_reserved = False
             self._record = None
             self.call_active.clear()
+            self._call_connected.clear()
             await self._send_status(
                 "ended", reason=finish_reason, outcome=finish_status
             )

--- a/src/agentcall/remote_dialer.py
+++ b/src/agentcall/remote_dialer.py
@@ -24,6 +24,7 @@ from urllib.parse import urlparse
 from .audio_bridge import MODEM_RATE, create_audio_bridge
 from .call_log import CallLogger, CallRecord
 from .dtmf import dtmf_tone
+from .pcm_stats import PcmFlowStats
 
 logger = logging.getLogger(__name__)
 
@@ -571,6 +572,11 @@ class RemoteWebDialerCoordinator:
             )
 
             started_at = time.monotonic()
+            # 上行第二段观测：泵从 endpoint 取走并写入音频桥的帧统计。
+            # 与 uplink1_lk_in（LiveKit 入站）、uplink3_as_write（ffmpeg AS
+            # 写入）对照，可二分「链路建立但无声」断在哪一段。
+            take_stats = PcmFlowStats("uplink2_pump_take")
+            pending_output_bytes = getattr(bridge, "pending_output_bytes", None)
             while not self._call_stop_requested.is_set():
                 if not self.modem.is_call_connected():
                     self._call_stop_reason = "remote_party_hangup"
@@ -588,6 +594,14 @@ class RemoteWebDialerCoordinator:
                         for chunk in browser_chunks:
                             record.write_downlink(chunk)
                     bridge.write_modem_chunks(browser_chunks)
+                    for chunk in browser_chunks:
+                        take_stats.add(chunk)
+                if take_stats.due():  # 到期才取 pending，避免每 10ms 拿一次桥锁
+                    take_stats.maybe_log(
+                        pending=(
+                            pending_output_bytes() if pending_output_bytes else "n/a"
+                        ),
+                    )
 
                 modem_pcm = bridge.read_modem_chunk()
                 if modem_pcm:

--- a/src/agentcall/remote_dialer.py
+++ b/src/agentcall/remote_dialer.py
@@ -461,6 +461,7 @@ class RemoteWebDialerCoordinator:
         bridge: AudioBridgeLike | None = None
         record: CallRecord | None = None
         connected = False
+        snapshot_task: asyncio.Task[None] | None = None
         finish_status = "failed"
         finish_reason = "edge_error"
         try:
@@ -524,6 +525,12 @@ class RemoteWebDialerCoordinator:
                 record.log_event("answered", source=REMOTE_CALL_SOURCE)
             await self._send_status("connected")
             self._publish({"type": "remote_call", "status": "connected"})
+            # connected 若因数据通道瞬时断连丢包，靠独立任务周期重发规范快照兜住
+            # （固定 connected，不随 _last_status 漂移）；与音频泵解耦，网络发送不
+            # 阻塞 10ms 热循环（#74）。
+            snapshot_task = asyncio.create_task(
+                self._status_snapshot_loop({"type": "status", "status": "connected"})
+            )
 
             started_at = time.monotonic()
             while not self._call_stop_requested.is_set():
@@ -549,6 +556,7 @@ class RemoteWebDialerCoordinator:
                     if record is not None:
                         record.write_uplink(modem_pcm)
                     self.endpoint.push_modem_audio(modem_pcm)
+
                 await asyncio.sleep(0.01)
 
             finish_status = "completed"
@@ -562,6 +570,8 @@ class RemoteWebDialerCoordinator:
                 "failed", code="edge_error", reason="edge_error"
             )
         finally:
+            if snapshot_task is not None:
+                snapshot_task.cancel()
             self._bridge = None
             if bridge is not None:
                 try:
@@ -635,6 +645,27 @@ class RemoteWebDialerCoordinator:
             await self.endpoint.send_event(event)
         except Exception as exc:  # noqa: BLE001
             logger.debug("远程状态发送失败: %s", type(exc).__name__)
+
+    async def _status_snapshot_loop(
+        self, snapshot: dict[str, Any], interval: float = 1.0
+    ) -> None:
+        """通话期间每 ~1s 重发一个**固定**状态快照的独立任务。
+
+        ``send_event`` 在数据通道瞬时断连（``browser_connected`` 为 False）时会
+        静默丢弃，首个 ``connected`` 若恰好丢包，客户端会卡在旧状态（真人号响铃
+        较久时更易触发）。本任务与音频泵解耦（网络发送不阻塞 10ms 热循环），且
+        重发调用方传入的固定快照，不读可能被 ``media_ready``/``failed`` 覆盖的
+        ``_last_status``。最小修复；完整 seq/ping/HTTP 兜底方案见 #74。
+        """
+        try:
+            while True:
+                await asyncio.sleep(interval)
+                try:
+                    await self.endpoint.send_event(dict(snapshot))
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug("远程状态快照重发失败: %s", type(exc).__name__)
+        except asyncio.CancelledError:
+            pass
 
     def _publish(self, event: dict[str, Any]) -> None:
         if self._publish_event is not None:

--- a/src/agentcall/web/server.py
+++ b/src/agentcall/web/server.py
@@ -429,7 +429,11 @@ async def _send_sms(request: web.Request) -> web.Response:
         else None
     )
     if not is_reply_target_allowed(
-        number, hub, call_logger, extra_allowed=current_caller
+        number,
+        hub,
+        call_logger,
+        extra_allowed=current_caller,
+        allow_any=config.get_bool("SMS_ALLOW_ANY_TARGET"),
     ):
         return web.json_response(
             {"ok": False, "error": "只能给曾通话（来电/已接通的外呼）或发过短信的号码发送短信"},

--- a/tests/unit/test_audio_bridge.py
+++ b/tests/unit/test_audio_bridge.py
@@ -47,7 +47,7 @@ def test_ffmpeg_uac_write_payload_keeps_silence_clock_when_empty():
     bridge = make_ffmpeg_bridge()
     silence = b"\x00" * NMEA_WRITE_SIZE
 
-    assert bridge._next_write_payload(silence) == silence
+    assert bridge._next_write_payload(silence) == (silence, 0)
 
 
 def test_ffmpeg_uac_write_payload_pads_partial_agent_audio():
@@ -55,11 +55,12 @@ def test_ffmpeg_uac_write_payload_pads_partial_agent_audio():
     silence = b"\x00" * NMEA_WRITE_SIZE
     bridge.write_modem_chunks([b"\x01\x02\x03"])
 
-    payload = bridge._next_write_payload(silence)
+    payload, real_bytes = bridge._next_write_payload(silence)
 
     assert len(payload) == NMEA_WRITE_SIZE
     assert payload[:3] == b"\x01\x02\x03"
     assert payload[3:] == b"\x00" * (NMEA_WRITE_SIZE - 3)
+    assert real_bytes == 3
     assert bridge.pending_output_bytes() == 0
 
 
@@ -70,9 +71,10 @@ def test_ffmpeg_uac_write_payload_consumes_one_realtime_frame():
     remainder = b"\x22" * 7
     bridge.write_modem_chunks([first_frame + remainder])
 
-    payload = bridge._next_write_payload(silence)
+    payload, real_bytes = bridge._next_write_payload(silence)
 
     assert payload == first_frame
+    assert real_bytes == NMEA_WRITE_SIZE
     assert bridge.pending_output_bytes() == len(remainder)
 
 

--- a/tests/unit/test_contacts.py
+++ b/tests/unit/test_contacts.py
@@ -92,3 +92,17 @@ def test_extra_allowed_current_caller_bypasses_history():
 def test_none_sources_reject_but_extra_allowed_still_works():
     assert not is_reply_target_allowed("10086", None, None)
     assert is_reply_target_allowed("10086", None, None, extra_allowed="10086")
+
+
+def test_allow_any_bypasses_contact_check_for_nonempty_number():
+    """开发期总开关:allow_any 放行任意非空号码,无需已联系过。"""
+    assert is_reply_target_allowed(
+        "18800000000", FakeHub([]), FakeCallLogger([]), allow_any=True
+    )
+    assert is_reply_target_allowed("13900000000", None, None, allow_any=True)
+
+
+def test_allow_any_still_rejects_empty_number():
+    """allow_any 也不放行空号码(空号码一律拒绝)。"""
+    assert not is_reply_target_allowed("", None, None, allow_any=True)
+    assert not is_reply_target_allowed("   ", None, None, allow_any=True)

--- a/tests/unit/test_pcm_stats.py
+++ b/tests/unit/test_pcm_stats.py
@@ -1,0 +1,93 @@
+"""PcmFlowStats：音频链路周期统计（隐私安全，只记数字）。"""
+
+from __future__ import annotations
+
+import logging
+import struct
+
+from agentcall.pcm_stats import PcmFlowStats
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.now = 100.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+def make_stats(interval: float = 5.0) -> tuple[PcmFlowStats, FakeClock]:
+    clock = FakeClock()
+    return PcmFlowStats("test_seg", interval_seconds=interval, clock=clock), clock
+
+
+def pcm_of(*samples: int) -> bytes:
+    return struct.pack(f"<{len(samples)}h", *samples)
+
+
+def test_no_log_before_interval(caplog):
+    stats, clock = make_stats()
+    stats.add(pcm_of(1, 2, 3))
+    clock.now += 4.9
+
+    assert stats.due() is False
+    with caplog.at_level(logging.INFO, logger="agentcall.pcm_stats"):
+        assert stats.maybe_log() is False
+    assert not caplog.records
+
+    clock.now += 0.1
+    assert stats.due() is True
+
+
+def test_logs_frames_bytes_peak_and_resets(caplog):
+    stats, clock = make_stats()
+    stats.add(pcm_of(100, -32768, 5))
+    stats.add(pcm_of(7))
+    clock.now += 5.0
+
+    with caplog.at_level(logging.INFO, logger="agentcall.pcm_stats"):
+        assert stats.maybe_log(queued=3) is True
+    assert len(caplog.records) == 1
+    message = caplog.records[0].getMessage()
+    assert "test_seg" in message
+    assert "frames=2" in message
+    assert "bytes=8" in message
+    assert "peak=32768" in message
+    assert "queued=3" in message
+
+    # 复位后新窗口从零累计。
+    caplog.clear()
+    clock.now += 5.0
+    with caplog.at_level(logging.INFO, logger="agentcall.pcm_stats"):
+        assert stats.maybe_log() is True
+    assert "frames=0 bytes=0 peak=0" in caplog.records[0].getMessage()
+
+
+def test_zero_frame_window_still_logs(caplog):
+    """整窗一帧未到也要按期打 frames=0——断流定位靠这个信号。"""
+    stats, clock = make_stats()
+    clock.now += 6.0
+
+    with caplog.at_level(logging.INFO, logger="agentcall.pcm_stats"):
+        assert stats.maybe_log() is True
+    assert "frames=0 bytes=0 peak=0" in caplog.records[0].getMessage()
+
+
+def test_all_zero_pcm_keeps_peak_zero(caplog):
+    """全零 PCM 帧数照记、峰值保持 0——区分「无帧」与「有帧但全零」。"""
+    stats, clock = make_stats()
+    stats.add(b"\x00" * 640)
+    clock.now += 5.0
+
+    with caplog.at_level(logging.INFO, logger="agentcall.pcm_stats"):
+        assert stats.maybe_log() is True
+    message = caplog.records[0].getMessage()
+    assert "frames=1" in message
+    assert "peak=0" in message
+
+
+def test_odd_length_pcm_does_not_crash():
+    stats, clock = make_stats()
+    stats.add(b"\x01")  # 半个采样：字节照计，峰值跳过
+    clock.now += 5.0
+    assert stats.maybe_log() is True

--- a/tests/unit/test_remote_dialer.py
+++ b/tests/unit/test_remote_dialer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import contextlib
 import inspect
 import json
 import time
@@ -302,6 +303,33 @@ def test_media_must_be_ready_before_dial() -> None:
 
         assert not any(name == "dial" for name, _args in modem.calls)
         assert endpoint.closed is True
+
+    asyncio.run(run())
+
+
+def test_status_snapshot_loop_resends_fixed_connected() -> None:
+    """#74：快照循环周期性重发**固定** connected，兜住首个 connected 丢包；
+    即使 _last_status 被 media_ready 覆盖，重发的仍是 connected。"""
+
+    async def run() -> None:
+        endpoint = FakeRemoteEndpoint()
+        coordinator = _coordinator(endpoint, FakeModem(), FakeBridge())
+        # 模拟通话中 _last_status 被 media_ready 覆盖——快照不得读它
+        coordinator._last_status = {"type": "status", "status": "media_ready"}
+        task = asyncio.create_task(
+            coordinator._status_snapshot_loop(
+                {"type": "status", "status": "connected"}, interval=0.01
+            )
+        )
+        await _wait_for(
+            lambda: sum(e.get("status") == "connected" for e in endpoint.events) >= 2
+        )
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+        # 重发的全部是固定的 connected，没有把被覆盖的 media_ready 发出去
+        assert all(e.get("status") == "connected" for e in endpoint.events)
+        assert sum(e.get("status") == "connected" for e in endpoint.events) >= 2
 
     asyncio.run(run())
 

--- a/tests/unit/test_remote_dialer.py
+++ b/tests/unit/test_remote_dialer.py
@@ -252,16 +252,18 @@ async def _wait_for(predicate, timeout: float = 1.0) -> None:
     raise AssertionError("condition was not met before timeout")
 
 
-def _runtime(*, dtmf_mode: str = "inband") -> RemoteDialerRuntimeConfig:
+def _runtime(
+    *, dtmf_mode: str = "inband", grace: float = 0.05, connect_timeout: float = 0.2
+) -> RemoteDialerRuntimeConfig:
     return RemoteDialerRuntimeConfig(
         audio_mode="uac",
         audio_keyword="Interface",
         pcm_port=None,
         pcm_baudrate=921600,
         tx_gain=1.0,
-        disconnect_grace_seconds=0.05,
+        disconnect_grace_seconds=grace,
         outbound_max_seconds=2.0,
-        connect_timeout_seconds=0.2,
+        connect_timeout_seconds=connect_timeout,
         dtmf_mode=dtmf_mode,
     )
 
@@ -273,13 +275,17 @@ def _coordinator(
     *,
     call_logger: CallLogger | None = None,
     dtmf_mode: str = "inband",
+    grace: float = 0.05,
+    connect_timeout: float = 0.2,
 ) -> RemoteWebDialerCoordinator:
     return RemoteWebDialerCoordinator(
         session_id="session-test",
         expires_at=time.time() + 60,
         modem=modem,  # type: ignore[arg-type]
         endpoint=endpoint,
-        runtime=_runtime(dtmf_mode=dtmf_mode),
+        runtime=_runtime(
+            dtmf_mode=dtmf_mode, grace=grace, connect_timeout=connect_timeout
+        ),
         bridge_factory=lambda **_kwargs: bridge,  # type: ignore[arg-type]
         call_logger=call_logger,
         reserve_line=lambda _owner: None,
@@ -330,6 +336,90 @@ def test_status_snapshot_loop_resends_fixed_connected() -> None:
         # 重发的全部是固定的 connected，没有把被覆盖的 media_ready 发出去
         assert all(e.get("status") == "connected" for e in endpoint.events)
         assert sum(e.get("status") == "connected" for e in endpoint.events) >= 2
+
+    asyncio.run(run())
+
+
+def test_ringing_media_blip_does_not_hang_up() -> None:
+    """#75：振铃期（未接通）手机音轨短暂丢失、但控制连接仍在时，不得挂断物理
+    振铃；应因 connect_timeout 走 not_connected，而非 media/control_disconnected。"""
+
+    async def run() -> None:
+        endpoint = FakeRemoteEndpoint(media_ready=True)
+        modem = FakeModem(auto_connect=False)  # 维持振铃、始终不接通
+        coordinator = _coordinator(endpoint, modem, FakeBridge())
+        task = asyncio.create_task(coordinator.run())
+        await _wait_for(lambda: endpoint.connected)
+        await endpoint.commands.put(
+            {"type": "dial", "number": "10086", "idempotency_key": "ring-phase-test"}
+        )
+        await _wait_for(lambda: any(name == "dial" for name, _ in modem.calls))
+        # 音轨抖动（media_ready=False），但控制连接（browser_connected）保持
+        endpoint._media_ready = False
+        await _wait_for(lambda: any(e.get("status") == "ended" for e in endpoint.events))
+        coordinator.request_stop("test_done")
+        await task
+        ended = [e for e in endpoint.events if e.get("status") == "ended"]
+        assert ended and ended[-1].get("reason") == "not_connected"
+        assert all(e.get("reason") != "control_disconnected" for e in endpoint.events)
+        assert all(e.get("reason") != "media_disconnected" for e in endpoint.events)
+
+    asyncio.run(run())
+
+
+def test_ringing_control_disconnect_hangs_up() -> None:
+    """#75：振铃期控制连接（browser_connected）真断超过 grace，仍按预期挂断，
+    reason=control_disconnected（不回归断线保护）。"""
+
+    async def run() -> None:
+        endpoint = FakeRemoteEndpoint(media_ready=True)
+        modem = FakeModem(auto_connect=False)
+        coordinator = _coordinator(endpoint, modem, FakeBridge())
+        task = asyncio.create_task(coordinator.run())
+        await _wait_for(lambda: endpoint.connected)
+        await endpoint.commands.put(
+            {"type": "dial", "number": "10086", "idempotency_key": "ring-phase-test"}
+        )
+        await _wait_for(lambda: any(name == "dial" for name, _ in modem.calls))
+        endpoint._browser_connected = False  # 控制连接真断
+        await _wait_for(lambda: any(e.get("status") == "ended" for e in endpoint.events))
+        coordinator.request_stop("test_done")
+        await task
+        ended = [e for e in endpoint.events if e.get("status") == "ended"]
+        assert ended and ended[-1].get("reason") == "control_disconnected"
+
+    asyncio.run(run())
+
+
+def test_phase_switch_resets_disconnect_timer() -> None:
+    """#75：振铃期控制断计时未到 grace 时物理接通、媒体仍未恢复——阶段切到
+    「已接通」必须重置计时，享有完整媒体 grace；不得沿用残留计时立即挂断
+    （否则仍表现为「接通即掉」）。"""
+
+    async def run() -> None:
+        endpoint = FakeRemoteEndpoint(media_ready=True)
+        modem = FakeModem(auto_connect=False)
+        coordinator = _coordinator(
+            endpoint, modem, FakeBridge(), grace=0.5, connect_timeout=3.0
+        )
+        task = asyncio.create_task(coordinator.run())
+        await _wait_for(lambda: endpoint.connected)
+        await endpoint.commands.put(
+            {"type": "dial", "number": "10086", "idempotency_key": "phase-switch-key"}
+        )
+        await _wait_for(lambda: any(name == "dial" for name, _ in modem.calls))
+        # 振铃期：控制连接断，计时开始（grace=0.5）
+        endpoint._browser_connected = False
+        await asyncio.sleep(0.2)  # < grace，计时进行中未触发
+        # 物理接通，但媒体仍未恢复：进入接通阶段，判据切 media_ready
+        endpoint._media_ready = False
+        modem.connected = True
+        await _wait_for(lambda: coordinator._call_connected.is_set(), timeout=1.0)
+        await asyncio.sleep(0.4)  # 接通后 0.4s（< 完整 grace 0.5）
+        # 若未重置：残留计时(0.2s起)在接通后约 0.3s 即挂断；重置后此刻不应挂
+        assert not coordinator._call_stop_requested.is_set()
+        coordinator.request_stop("test_done")
+        await task
 
     asyncio.run(run())
 


### PR DESCRIPTION
## 远程真实号码拨打修复批次

### 修复
- **#74 UI 卡「拨号中」**:`connected` 状态经 LiveKit 数据通道瞬断丢包后无恢复手段 → 独立任务周期重发固定 connected 快照(与音频泵解耦,不阻塞 10ms 热循环)。`dc240bd`
- **#75 接通即掉**:媒体断线宽限计时在振铃期就启动,5s 后自 ATH → phase-aware 守护:振铃期看控制连接、接通后看媒体轨,阶段切换重置计时。`d4b0aab`
- **上行链路观测**:三段 5s 统计(LiveKit 收帧/泵取走/写模组),定位「对方听不到」类问题。`c251337`
- **SMS_ALLOW_ANY_TARGET** 开发期总开关(默认 false,不改变默认安全姿态)。`f5ef61e`

### 真机验收(owner,2026-07-12)
- 远程拨 10086:接通后稳定 104s / 98s,UI 状态正常,IVR 全程在线 ✅(#74 #75 复现消除)
- 远程拨 owner 本人手机:双向人耳验证——两端均能清楚听到对方 ✅
- 插桩数据:通话中三段均满速率(250帧/5s、50写/5s),峰值随说话 2.5k~28k 起落,零丢帧、缓冲稳定 ~200ms
- 遗留:一通(11:32)App 音频在 LiveKit 层零帧到达(录音 downlink 0 字节),之后各通均正常——已另开 issue 跟踪偶发根因

### 测试
全量 pytest 742 passed / ruff / mypy 全绿;新增振铃期断线、阶段切换重置、allow_any 等单测。

Closes #74
Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3ym8uHa4Xq46rZBDCXaDb