### PR TITLE
feat: spoken DTMF recovery guard + Realtime MRC parity (Refs #80)

### DIFF
--- a/data/number_profiles.example.json
+++ b/data/number_profiles.example.json
@@ -33,7 +33,8 @@
         "en": "You are calling China Mobile's hotline 10086 on the owner's behalf to check the data usage on the owner's number. You are the caller asking for help — not an agent, never impersonate the owner. After the call connects, listen through the first IVR menu announcement completely; do not speak during IVR playback or transfer hold. Only say short keywords when the system explicitly prompts for voice input, and never interrupt or introduce yourself. For keypad menus you must call the send_dtmf tool to actually press keys, not just say a digit. Once transferred to a human, explain your need in one sentence. Never make up figures or claim you have them before they are given — say you're still waiting. Confirm the result in one sentence."
       },
       "opening": {"zh": "你好，我想查一下这个号码的流量使用情况。", "en": "Hi, I'd like to check data usage."},
-      "opening_mode": "wait"
+      "opening_mode": "wait",
+      "dtmf_spoken_followup": true
     },
     {
       "id": "china_unicom_data",

--- a/src/agentcall/agents/base.py
+++ b/src/agentcall/agents/base.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
     from .tools import ToolRegistry
@@ -78,6 +78,21 @@ class VoiceAgent(ABC):
 
     async def say(self, instructions: str) -> None:
         """让 Agent 主动说一段话；不支持的实现可以忽略。"""
+
+    async def external_tool_result(
+        self,
+        name: str,
+        result: dict[str, Any],
+        *,
+        source: str,
+    ) -> bool:
+        """Record an externally executed tool fact without requesting a reply.
+
+        Providers that cannot add a reliable standalone context item return
+        ``False``. Callers must never fabricate a function-call id as fallback.
+        """
+
+        return False
 
     @abstractmethod
     async def stop(self) -> None:

--- a/src/agentcall/agents/local_agent.py
+++ b/src/agentcall/agents/local_agent.py
@@ -315,6 +315,31 @@ class LocalPipelineAgent(VoiceAgent):
         if self._running:
             self._brain_queue.put(_SayRequest(instructions))
 
+    async def external_tool_result(
+        self,
+        name: str,
+        result: dict[str, Any],
+        *,
+        source: str,
+    ) -> bool:
+        success = result.get("success") is True
+        count = result.get("count")
+        safe_count = count if isinstance(count, int) and count >= 0 else 0
+        mode = result.get("mode")
+        safe_mode = mode if isinstance(mode, str) else "unknown"
+        with self._messages_lock:
+            self._messages.append(
+                {
+                    "role": "system",
+                    "content": (
+                        f"[external_tool_result] {name} was executed by {source}; "
+                        f"success={str(success).lower()}, count={safe_count}, "
+                        f"mode={safe_mode}. Do not speak merely to acknowledge it."
+                    ),
+                }
+            )
+        return True
+
     async def stop(self) -> None:
         self._running = False
         for thread in (self._vad_thread, self._brain_thread):

--- a/src/agentcall/agents/openai_agent.py
+++ b/src/agentcall/agents/openai_agent.py
@@ -15,6 +15,8 @@ import asyncio
 import base64
 import json
 import logging
+import threading
+import time
 from datetime import datetime
 from typing import Any, Callable
 
@@ -33,6 +35,8 @@ DEFAULT_REALTIME_URL = "wss://api.openai.com/v1/realtime"
 
 # 输入音频转写模型（session.input_audio_transcription）。
 TRANSCRIPTION_MODEL = "gpt-4o-mini-transcribe"
+_MANUAL_RESPONSE_CREATED_TIMEOUT_SECONDS = 5.0
+_MANUAL_RESPONSE_SEND_TIMEOUT_SECONDS = 5.0
 
 # 重连成功后让 Agent 主动安抚对方的提示词（与 qwen_agent 语义一致）。
 RECONNECT_NOTICE = "请直接用中文说：抱歉刚才信号不太好，请继续。"
@@ -101,6 +105,17 @@ class OpenAIVoiceAgent(VoiceAgent):
         self._running = False
         self._handled_tool_calls: set[str] = set()
         self._instructions: str | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._manual_response_enabled = False
+        self._manual_response_lock = threading.Lock()
+        self._manual_response_timer: threading.Timer | None = None
+        self._manual_response_generation = 0
+        self._manual_response_watchdog_timer: threading.Timer | None = None
+        self._manual_response_watchdog_generation = 0
+        self._manual_response_first_at: float | None = None
+        self._manual_response_request_pending = False
+        self._manual_response_outstanding = 0
+        self._manual_response_pending_after_flight = False
 
     # ---- 连接管理 ----
 
@@ -149,7 +164,14 @@ class OpenAIVoiceAgent(VoiceAgent):
                 "input": {
                     "format": {"type": "audio/pcm", "rate": self.input_rate},
                     # 打断事件本轮忽略，半双工由 call_agent 统一管理。
-                    "turn_detection": {"type": "server_vad"},
+                    "turn_detection": {
+                        "type": "server_vad",
+                        **(
+                            {"create_response": False}
+                            if self._manual_response_enabled
+                            else {}
+                        ),
+                    },
                     "transcription": {"model": TRANSCRIPTION_MODEL},
                 },
                 "output": {
@@ -168,8 +190,11 @@ class OpenAIVoiceAgent(VoiceAgent):
         logger.info("OpenAI Realtime 连接已建立: %s", self.model)
 
     async def start(self, on_audio_out: Callable[[bytes], None]) -> None:
+        self._loop = asyncio.get_running_loop()
         self._on_audio_out = on_audio_out
         self._running = True
+        self._manual_response_enabled = config.get_bool("MANUAL_RESPONSE_CONTROL")
+        self._reset_manual_response_state()
         self._instructions = self._session_instructions or _default_instructions()
         await self._connect()
         self._recv_task = asyncio.create_task(self._recv_loop())
@@ -282,6 +307,199 @@ class OpenAIVoiceAgent(VoiceAgent):
             return False
         return True
 
+    def _reset_manual_response_state(self) -> None:
+        with self._manual_response_lock:
+            self._cancel_manual_response_timer_locked()
+            self._cancel_manual_response_watchdog_locked()
+            self._manual_response_first_at = None
+            self._manual_response_request_pending = False
+            self._manual_response_outstanding = 0
+            self._manual_response_pending_after_flight = False
+
+    def _cancel_manual_response_control(self) -> None:
+        with self._manual_response_lock:
+            self._cancel_manual_response_timer_locked()
+            self._cancel_manual_response_watchdog_locked()
+            self._manual_response_first_at = None
+            self._manual_response_request_pending = False
+            self._manual_response_outstanding = 0
+            self._manual_response_pending_after_flight = False
+
+    def _cancel_manual_response_timer_locked(self) -> None:
+        timer = self._manual_response_timer
+        self._manual_response_timer = None
+        self._manual_response_generation += 1
+        if timer is not None:
+            timer.cancel()
+
+    def _cancel_manual_response_watchdog_locked(self) -> None:
+        timer = self._manual_response_watchdog_timer
+        self._manual_response_watchdog_timer = None
+        self._manual_response_watchdog_generation += 1
+        if timer is not None:
+            timer.cancel()
+
+    def _on_user_transcription_completed(self) -> None:
+        if self._manual_response_enabled:
+            self._schedule_manual_response_timer()
+
+    def _schedule_manual_response_timer(self) -> None:
+        now = time.monotonic()
+        with self._manual_response_lock:
+            if not self._running or self._ws is None:
+                return
+            if self._manual_response_request_pending:
+                self._manual_response_pending_after_flight = True
+                self._manual_response_first_at = None
+                return
+            if self._manual_response_first_at is None:
+                self._manual_response_first_at = now
+            timer = self._manual_response_timer
+            if timer is not None:
+                timer.cancel()
+            self._manual_response_generation += 1
+            generation = self._manual_response_generation
+            delay = self._manual_response_delay_locked(now)
+            next_timer = threading.Timer(
+                delay, self._fire_manual_response_timer, args=(generation,)
+            )
+            next_timer.daemon = True
+            self._manual_response_timer = next_timer
+            next_timer.start()
+
+    def _manual_response_delay_locked(self, now: float) -> float:
+        silence_seconds = max(0, config.get_int("MANUAL_RESPONSE_SILENCE_MS")) / 1000
+        max_wait_seconds = max(0, config.get_int("MANUAL_RESPONSE_MAX_WAIT_MS")) / 1000
+        if max_wait_seconds <= 0 or self._manual_response_first_at is None:
+            return silence_seconds
+        elapsed = now - self._manual_response_first_at
+        return min(silence_seconds, max(0.0, max_wait_seconds - elapsed))
+
+    def _fire_manual_response_timer(self, generation: int) -> None:
+        with self._manual_response_lock:
+            if generation != self._manual_response_generation or not self._running:
+                return
+            self._manual_response_timer = None
+            if self._manual_response_outstanding > 0:
+                self._manual_response_pending_after_flight = True
+                self._manual_response_first_at = None
+                return
+            ws = self._ws
+            loop = self._loop
+            if ws is None or loop is None or not loop.is_running():
+                self._manual_response_first_at = None
+                return
+            self._manual_response_first_at = None
+            self._manual_response_request_pending = True
+            self._start_manual_response_watchdog_locked(
+                _MANUAL_RESPONSE_CREATED_TIMEOUT_SECONDS
+            )
+
+        try:
+            future = asyncio.run_coroutine_threadsafe(
+                self._send_manual_response(ws), loop
+            )
+            future.result(timeout=_MANUAL_RESPONSE_SEND_TIMEOUT_SECONDS)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "手动触发 OpenAI 回复失败: error_type=%s", type(exc).__name__
+            )
+            should_schedule = False
+            with self._manual_response_lock:
+                self._manual_response_request_pending = False
+                if self._manual_response_outstanding == 0:
+                    self._cancel_manual_response_watchdog_locked()
+                if self._manual_response_pending_after_flight and self._running:
+                    self._manual_response_pending_after_flight = False
+                    should_schedule = True
+            if should_schedule:
+                self._schedule_manual_response_timer()
+
+    async def _send_manual_response(self, ws: Any) -> None:
+        if ws is not self._ws or not self._running:
+            raise ConnectionError("Realtime connection changed")
+        await ws.send(json.dumps({"type": "response.create"}))
+
+    def _on_response_created(self) -> None:
+        if not self._manual_response_enabled:
+            return
+        with self._manual_response_lock:
+            if not self._running:
+                return
+            self._manual_response_request_pending = False
+            self._manual_response_outstanding += 1
+            if self._manual_response_outstanding == 1:
+                self._start_manual_response_watchdog_locked()
+
+    def _start_manual_response_watchdog_locked(
+        self, timeout_seconds: float | None = None
+    ) -> None:
+        timer = self._manual_response_watchdog_timer
+        if timer is not None:
+            timer.cancel()
+        self._manual_response_watchdog_generation += 1
+        generation = self._manual_response_watchdog_generation
+        if timeout_seconds is None:
+            timeout_seconds = (
+                max(0, config.get_int("MANUAL_RESPONSE_MAX_WAIT_MS")) / 1000
+            )
+        if timeout_seconds <= 0:
+            return
+        next_timer = threading.Timer(
+            timeout_seconds,
+            self._fire_manual_response_watchdog,
+            args=(generation,),
+        )
+        next_timer.daemon = True
+        self._manual_response_watchdog_timer = next_timer
+        next_timer.start()
+
+    def _fire_manual_response_watchdog(self, generation: int) -> None:
+        should_schedule = False
+        with self._manual_response_lock:
+            if (
+                generation != self._manual_response_watchdog_generation
+                or not self._running
+                or (
+                    not self._manual_response_request_pending
+                    and self._manual_response_outstanding <= 0
+                )
+            ):
+                return
+            logger.warning(
+                "手动应答控制等待 OpenAI response.created/done 超时，清理状态"
+            )
+            self._manual_response_watchdog_timer = None
+            self._manual_response_request_pending = False
+            self._manual_response_outstanding = 0
+            if self._manual_response_pending_after_flight:
+                self._manual_response_pending_after_flight = False
+                should_schedule = True
+        if should_schedule:
+            self._schedule_manual_response_timer()
+
+    def _on_response_done(self) -> None:
+        if not self._manual_response_enabled:
+            return
+        should_schedule = False
+        with self._manual_response_lock:
+            if self._manual_response_outstanding > 0:
+                self._manual_response_outstanding -= 1
+            if (
+                self._manual_response_outstanding == 0
+                and not self._manual_response_request_pending
+            ):
+                self._cancel_manual_response_watchdog_locked()
+            if (
+                self._manual_response_outstanding == 0
+                and self._manual_response_pending_after_flight
+                and self._running
+            ):
+                self._manual_response_pending_after_flight = False
+                should_schedule = True
+        if should_schedule:
+            self._schedule_manual_response_timer()
+
     def _nudge_after_repeat_suppressed(self, _transcript: str) -> None:
         try:
             asyncio.get_running_loop().create_task(
@@ -294,7 +512,14 @@ class OpenAIVoiceAgent(VoiceAgent):
         self._emit_repeat_stuck(f"复读抑制连续触发 {count} 次，判定模型卡死")
 
     async def stop(self) -> None:
-        self._running = False
+        with self._manual_response_lock:
+            self._running = False
+            self._cancel_manual_response_timer_locked()
+            self._cancel_manual_response_watchdog_locked()
+            self._manual_response_first_at = None
+            self._manual_response_request_pending = False
+            self._manual_response_outstanding = 0
+            self._manual_response_pending_after_flight = False
         ws, self._ws = self._ws, None
         if ws:
             try:
@@ -338,6 +563,7 @@ class OpenAIVoiceAgent(VoiceAgent):
                 logger.error("OpenAI 接收循环异常: %s", exc)
             if not self._running:
                 break
+            self._cancel_manual_response_control()
             # 立即摘掉死连接：重连期间 send_audio/say 看到 _ws 为 None 会
             # 静默丢帧（对齐 qwen 语义），否则每 10ms 一帧的上行都对死连接
             # send 并各刷一条 warning（重连数秒内可积数百条）。
@@ -364,6 +590,7 @@ class OpenAIVoiceAgent(VoiceAgent):
             if transcript:
                 logger.info("[上行·用户] %s", transcript)
                 self._emit_transcript("user", transcript)
+                self._on_user_transcription_completed()
         elif event_type in (
             "response.audio_transcript.done",
             "response.output_audio_transcript.done",
@@ -387,6 +614,8 @@ class OpenAIVoiceAgent(VoiceAgent):
                 asyncio.get_running_loop().create_task(
                     self._dispatch_tool_call(name, call_id, arguments, self._ws)
                 )
+        elif event_type == "response.created":
+            self._on_response_created()
         elif event_type == "input_audio_buffer.speech_started":
             # server_vad 的打断事件本轮忽略（半双工由 call_agent 管理）。
             pass
@@ -399,6 +628,7 @@ class OpenAIVoiceAgent(VoiceAgent):
             else:
                 self._audio_gate.complete_response(_response_id(event))
                 logger.debug("OpenAI 回复轮次完成")
+            self._on_response_done()
         elif event_type == "error":
             logger.error("OpenAI Realtime 错误: %s", event)
 

--- a/src/agentcall/agents/openai_agent.py
+++ b/src/agentcall/agents/openai_agent.py
@@ -242,6 +242,46 @@ class OpenAIVoiceAgent(VoiceAgent):
             # 重连由接收循环统一负责。
             logger.warning("发送说话指令失败: %s", exc)
 
+    async def external_tool_result(
+        self,
+        name: str,
+        result: dict[str, Any],
+        *,
+        source: str,
+    ) -> bool:
+        """Append a supported system item; do not fabricate a function call."""
+
+        ws = self._ws
+        if ws is None:
+            return False
+        success = result.get("success") is True
+        count = result.get("count")
+        safe_count = count if isinstance(count, int) and count >= 0 else 0
+        mode = result.get("mode")
+        safe_mode = mode if isinstance(mode, str) else "unknown"
+        text = (
+            f"[external_tool_result] {name} was executed by {source}; "
+            f"success={str(success).lower()}, count={safe_count}, mode={safe_mode}. "
+            "This is context only; do not speak merely to acknowledge it."
+        )
+        try:
+            await ws.send(
+                json.dumps(
+                    {
+                        "type": "conversation.item.create",
+                        "item": {
+                            "type": "message",
+                            "role": "system",
+                            "content": [{"type": "input_text", "text": text}],
+                        },
+                    }
+                )
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("写入外部工具结果失败: error_type=%s", type(exc).__name__)
+            return False
+        return True
+
     def _nudge_after_repeat_suppressed(self, _transcript: str) -> None:
         try:
             asyncio.get_running_loop().create_task(

--- a/src/agentcall/agents/qwen_agent.py
+++ b/src/agentcall/agents/qwen_agent.py
@@ -206,6 +206,22 @@ class _QwenCallback(OmniRealtimeCallback):
                 self._agent._audio_gate.complete_response(_response_id(response))  # noqa: SLF001
                 self._agent._on_response_done()  # noqa: SLF001
             logger.debug("千问回复轮次完成")
+        elif event_type == "session.updated":
+            session = response.get("session")
+            session_data = session if isinstance(session, dict) else {}
+            turn_detection = session_data.get("turn_detection")
+            turn_data = turn_detection if isinstance(turn_detection, dict) else {}
+            create_response = turn_data.get("create_response", "unknown")
+            requested = bool(
+                self._agent is not None
+                and self._agent._manual_response_enabled  # noqa: SLF001
+            )
+            logger.info(
+                "千问 Realtime session.updated: "
+                "manual_response_requested=%s create_response=%s",
+                requested,
+                create_response,
+            )
         elif event_type == "error":
             logger.error("千问 Realtime 错误: %s", response)
 

--- a/src/agentcall/call_agent.py
+++ b/src/agentcall/call_agent.py
@@ -13,6 +13,7 @@ from queue import Empty, Queue
 from typing import Callable
 
 from . import config
+from .agents.base import VoiceAgent
 from .agents.factory import create_agent
 from .agents.tools import ToolRegistry
 from .audio_bridge import (
@@ -28,6 +29,7 @@ from .call_tools import CallTools
 from .contacts import is_reply_target_allowed
 from .dial_queue import DialQueue, whitelist_from_env
 from .dtmf import dtmf_tone
+from .dtmf_followup import extract_spoken_dtmf
 from .events import EventHub
 from .modem import Eg25Modem
 from .monitor_playback import MonitorPlayback
@@ -67,6 +69,12 @@ HALF_DUPLEX_HANGOVER_SECONDS = 0.5
 # 挂断工具触发后延迟这么久再真正挂断，先让 Agent 播完告别语。
 # （仅作缺省值；每通会话开始时从 config.HANGUP_TOOL_DELAY_SECONDS 重新读取。）
 HANGUP_TOOL_DELAY_SECONDS = 4.5
+
+# Profile-gated fallback: wait briefly for a genuine tool call after the Agent
+# says it is pressing a key. The recent-send window closes transcript/tool races.
+DTMF_SPOKEN_FOLLOWUP_DELAY_SECONDS = 3.0
+DTMF_RECENT_SEND_WINDOW_SECONDS = 5.0
+_EXTERNAL_TOOL_RESULT_TIMEOUT_SECONDS = 2.0
 
 
 class CallSession:
@@ -133,6 +141,23 @@ class CallSession:
         self._prompt_gen_generation = 0
         self._prompt_gen_opening = ""
         self._prompt_gen_opening_mode = "say"
+        self._prompt_gen_dtmf_spoken_followup = False
+        self._dtmf_lock = threading.RLock()
+        self._recent_dtmf_sent: dict[str, tuple[float, str]] = {}
+        self._pending_dtmf_followups: dict[
+            int,
+            tuple[
+                threading.Timer,
+                str,
+                int,
+                float,
+                VoiceAgent,
+                CallRecord | None,
+            ],
+        ] = {}
+        self._next_dtmf_followup_id = 0
+        self._dtmf_dispatch_context = threading.local()
+        self._active_tools: ToolRegistry | None = None
 
     def _publish(self, event: dict) -> None:
         if self.hub:
@@ -166,6 +191,8 @@ class CallSession:
         self._prompt_gen_generation += 1
         self._prompt_gen_opening = ""
         self._prompt_gen_opening_mode = "say"
+        self._prompt_gen_dtmf_spoken_followup = False
+        self._cancel_spoken_dtmf_followups(clear_recent=True)
         # 世代号推进与置活必须同锁原子完成：与 _deferred_hangup 的
         # 「校验世代号 → stop()」互斥，保证旧回调要么在新会话置活前跑完
         # （只影响已结束的旧会话），要么校验失败直接放弃。
@@ -177,7 +204,9 @@ class CallSession:
         self._thread.start()
 
     def stop(self) -> None:
-        self._active = False
+        with self._dtmf_lock:
+            self._active = False
+            self._cancel_spoken_dtmf_followups_locked()
         if self._loop and self._loop.is_running():
             asyncio.run_coroutine_threadsafe(self._shutdown(), self._loop)
 
@@ -189,7 +218,10 @@ class CallSession:
         except Exception as exc:  # noqa: BLE001
             logger.exception("通话处理异常: %s", exc)
         finally:
-            self._active = False
+            with self._dtmf_lock:
+                self._active = False
+                self._cancel_spoken_dtmf_followups_locked()
+                self._active_tools = None
             # 会话收尾统一取消未触发的延迟挂断，不让它跨到下一通。
             self._cancel_hangup_timer()
             self._loop.close()
@@ -293,14 +325,17 @@ class CallSession:
             agent = create_agent(self.provider)
             agent.set_session_instructions(self._build_agent_instructions(direction))
             agent.set_transcript_handler(
-                self._make_transcript_handler(record, transcripts)
+                self._make_transcript_handler(record, transcripts, agent)
             )
             agent.set_repeat_stuck_handler(self._request_repeat_stuck_wrap_up)
             # 面向用户的状态提示（如 local provider 首启下载模型进度）经 EventHub 播给 UI。
             agent.set_status_handler(
                 lambda text: self._publish({"type": "system", "text": text})
             )
-            agent.set_tools(self._build_tools())
+            tools = self._build_tools()
+            with self._dtmf_lock:
+                self._active_tools = tools
+            agent.set_tools(tools)
             if isinstance(bridge, SerialPcmAudioBridge):
                 bridge.set_ready_check(self.modem.pcm_ready)
             bridge.start()
@@ -366,6 +401,7 @@ class CallSession:
         self,
         record: CallRecord | None,
         transcripts: list[tuple[str, str]],
+        agent: VoiceAgent,
     ) -> Callable[[str, str], None]:
         """转写回调：累积到 transcripts（供摘要）、写通话记录、推送 UI。"""
 
@@ -381,6 +417,8 @@ class CallSession:
                     "caller": self.current_caller,
                 }
             )
+            if role == "agent":
+                self._schedule_spoken_dtmf_followup(agent, text)
 
         return on_transcript
 
@@ -615,7 +653,7 @@ class CallSession:
             get_record=lambda: self._record,
             schedule_hangup=self._schedule_deferred_hangup,
             is_sms_target_allowed=self._sms_target_allowed,
-            send_dtmf=self._send_dtmf_raw,
+            send_dtmf=self._send_dtmf_from_tool,
         )
         return tools.register()
 
@@ -780,6 +818,9 @@ class CallSession:
         self._prompt_gen_opening = str(result.get("opening") or "")
         mode = str(result.get("opening_mode") or "").strip().lower()
         self._prompt_gen_opening_mode = "wait" if mode == "wait" else "say"
+        self._prompt_gen_dtmf_spoken_followup = (
+            result.get("dtmf_spoken_followup") is True
+        )
         if result.get("ok") and str(result.get("scenario", "")).strip():
             return str(result["scenario"])
         return None
@@ -811,6 +852,7 @@ class CallSession:
                 scenario=scenario,
                 opening=opening,
                 opening_mode=str(result.get("opening_mode") or "").strip().lower() or "say",
+                dtmf_spoken_followup=result.get("dtmf_spoken_followup") is True,
                 error=error,
                 provider=provider,
                 model=model,
@@ -844,11 +886,153 @@ class CallSession:
             self._hangup_timer = timer
             timer.start()
 
+    def _schedule_spoken_dtmf_followup(
+        self, agent: VoiceAgent, transcript: str
+    ) -> None:
+        if not self._prompt_gen_dtmf_spoken_followup:
+            return
+        digits = extract_spoken_dtmf(transcript)
+        if digits is None:
+            return
+        with self._dtmf_lock:
+            if not self._active or not self._prompt_gen_dtmf_spoken_followup:
+                return
+            self._next_dtmf_followup_id += 1
+            followup_id = self._next_dtmf_followup_id
+            generation = self._session_generation
+            created_at = time.monotonic()
+            timer = threading.Timer(
+                DTMF_SPOKEN_FOLLOWUP_DELAY_SECONDS,
+                self._fire_spoken_dtmf_followup,
+                args=(followup_id,),
+            )
+            timer.daemon = True
+            self._pending_dtmf_followups[followup_id] = (
+                timer,
+                digits,
+                generation,
+                created_at,
+                agent,
+                self._record,
+            )
+            timer.start()
+
+    def _fire_spoken_dtmf_followup(self, followup_id: int) -> None:
+        with self._dtmf_lock:
+            pending = self._pending_dtmf_followups.pop(followup_id, None)
+            if pending is None:
+                return
+            _timer, digits, generation, created_at, agent, record = pending
+            if (
+                not self._active
+                or generation != self._session_generation
+                or not self._prompt_gen_dtmf_spoken_followup
+            ):
+                return
+            now = time.monotonic()
+            self._prune_recent_dtmf_locked(now)
+            previous = self._recent_dtmf_sent.get(digits)
+            if (
+                previous is not None
+                and now - previous[0] < DTMF_RECENT_SEND_WINDOW_SECONDS
+            ):
+                return
+            tools = self._active_tools
+            if tools is None:
+                return
+            self._dtmf_dispatch_context.source = "spoken_followup"
+            try:
+                # The timer thread is the worker: qvts/AT cannot block an Agent
+                # callback or the CallSession audio loop.
+                result = tools.dispatch("send_dtmf", {"digits": digits})
+            finally:
+                try:
+                    del self._dtmf_dispatch_context.source
+                except AttributeError:
+                    pass
+            executed_at = time.monotonic()
+
+        context_injected = self._notify_external_tool_result(agent, result)
+        if record is not None:
+            mode = result.get("mode")
+            record.log_event(
+                "dtmf_auto_followup",
+                count=len(digits),
+                mode=mode if isinstance(mode, str) else "unknown",
+                result="success" if result.get("success") is True else "failure",
+                delay_ms=round((executed_at - created_at) * 1000, 1),
+                source="agent_transcript",
+                context_injected=context_injected,
+            )
+
+    def _notify_external_tool_result(
+        self, agent: VoiceAgent, result: dict
+    ) -> bool:
+        loop = self._loop
+        if loop is None or not loop.is_running():
+            return False
+        safe_result = {
+            "success": result.get("success") is True,
+            "count": result.get("count") if isinstance(result.get("count"), int) else 0,
+            "mode": result.get("mode") if isinstance(result.get("mode"), str) else "unknown",
+        }
+        try:
+            future = asyncio.run_coroutine_threadsafe(
+                agent.external_tool_result(
+                    "send_dtmf", safe_result, source="spoken_followup"
+                ),
+                loop,
+            )
+            return bool(
+                future.result(timeout=_EXTERNAL_TOOL_RESULT_TIMEOUT_SECONDS)
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "外部 DTMF 结果未写入模型上下文: error_type=%s",
+                type(exc).__name__,
+            )
+            return False
+
+    def _cancel_spoken_dtmf_followups(self, *, clear_recent: bool = False) -> None:
+        with self._dtmf_lock:
+            self._cancel_spoken_dtmf_followups_locked()
+            if clear_recent:
+                self._recent_dtmf_sent.clear()
+
+    def _cancel_spoken_dtmf_followups_locked(self) -> None:
+        pending = list(self._pending_dtmf_followups.values())
+        self._pending_dtmf_followups.clear()
+        for timer, _digits, _generation, _created_at, _agent, _record in pending:
+            timer.cancel()
+
+    def _cancel_pending_dtmf_locked(self, digits: str) -> None:
+        matching = [
+            followup_id
+            for followup_id, pending in self._pending_dtmf_followups.items()
+            if pending[1] == digits
+        ]
+        for followup_id in matching:
+            timer, _digits, _generation, _created_at, _agent, _record = (
+                self._pending_dtmf_followups.pop(followup_id)
+            )
+            timer.cancel()
+
+    def _prune_recent_dtmf_locked(self, now: float) -> None:
+        expired = [
+            digits
+            for digits, (sent_at, _source) in self._recent_dtmf_sent.items()
+            if now - sent_at >= DTMF_RECENT_SEND_WINDOW_SECONDS
+        ]
+        for digits in expired:
+            del self._recent_dtmf_sent[digits]
+
     def send_dtmf(self, digits: str) -> tuple[bool, str | None]:
         """发送 DTMF；UAC 模式默认把双音作为带内 PCM 注入下行队列。"""
         mode = "unknown"
         try:
-            ok, mode = self._send_dtmf_raw(digits)
+            ok, mode = self._send_dtmf_raw(
+                digits, source="manual", deduplicate=False
+            )
         except Exception as exc:  # noqa: BLE001
             logger.warning("发送 DTMF 失败: error_type=%s", type(exc).__name__)
             if self._record is not None:
@@ -865,26 +1049,63 @@ class CallSession:
             )
         return (True, None) if ok else (False, "按键发送失败")
 
-    def _send_dtmf_raw(self, digits: str) -> tuple[bool, str]:
+    def _send_dtmf_from_tool(self, digits: str) -> tuple[bool, str]:
+        source = getattr(self._dtmf_dispatch_context, "source", "agent_tool")
+        return self._send_dtmf_raw(digits, source=source, deduplicate=True)
+
+    def _send_dtmf_raw(
+        self,
+        digits: str,
+        *,
+        source: str = "agent_tool",
+        deduplicate: bool = True,
+    ) -> tuple[bool, str]:
         mode = self._resolve_dtmf_mode()
-        ok = True
-        if mode in {"inband", "both"}:
-            tone = dtmf_tone(
-                digits,
-                MODEM_RATE,
-                tone_ms=config.get_int("DTMF_TONE_MS"),
-                amplitude=config.get_float("DTMF_TONE_AMPLITUDE"),
-            )
-            if not tone:
-                return False, mode
-            # 与 Agent 语音共用 _outgoing_audio，后续由 _drain_agent_audio
-            # 按既有下行链路送入桥；半双工 pending 判定也会自然把它当成正在说话。
-            if self._record is not None:
-                self._record.write_downlink(tone)
-            self._outgoing_audio.put(tone)
-        if mode in {"qvts", "both"}:
-            ok = self.modem.send_dtmf(digits)
-        return ok, mode
+        with self._dtmf_lock:
+            now = time.monotonic()
+            self._prune_recent_dtmf_locked(now)
+            previous = self._recent_dtmf_sent.get(digits)
+            if (
+                deduplicate
+                and previous is not None
+                and now - previous[0] < DTMF_RECENT_SEND_WINDOW_SECONDS
+                and (
+                    source == "spoken_followup"
+                    or previous[1] == "spoken_followup"
+                )
+            ):
+                logger.info(
+                    "抑制重复 DTMF: count=%d source=%s", len(digits), source
+                )
+                if source != "spoken_followup":
+                    self._cancel_pending_dtmf_locked(digits)
+                return True, mode
+
+            ok = True
+            sent = False
+            if mode in {"inband", "both"}:
+                tone = dtmf_tone(
+                    digits,
+                    MODEM_RATE,
+                    tone_ms=config.get_int("DTMF_TONE_MS"),
+                    amplitude=config.get_float("DTMF_TONE_AMPLITUDE"),
+                )
+                if not tone:
+                    return False, mode
+                # 与 Agent 语音共用 _outgoing_audio，后续由 _drain_agent_audio
+                # 按既有下行链路送入桥；半双工 pending 判定也会自然把它当成正在说话。
+                if self._record is not None:
+                    self._record.write_downlink(tone)
+                self._outgoing_audio.put(tone)
+                sent = True
+            if mode in {"qvts", "both"}:
+                ok = self.modem.send_dtmf(digits)
+                sent = sent or ok
+            if sent:
+                self._recent_dtmf_sent[digits] = (time.monotonic(), source)
+                if source != "spoken_followup":
+                    self._cancel_pending_dtmf_locked(digits)
+            return ok, mode
 
     def _resolve_dtmf_mode(self) -> str:
         configured = config.get_str("DTMF_MODE").strip().lower()

--- a/src/agentcall/dtmf_followup.py
+++ b/src/agentcall/dtmf_followup.py
@@ -1,0 +1,57 @@
+"""Conservative parsing for an Agent's spoken DTMF execution intent."""
+
+from __future__ import annotations
+
+import re
+
+_DIGIT_MAP = str.maketrans(
+    {
+        "零": "0",
+        "〇": "0",
+        "一": "1",
+        "幺": "1",
+        "二": "2",
+        "两": "2",
+        "三": "3",
+        "四": "4",
+        "五": "5",
+        "六": "6",
+        "七": "7",
+        "八": "8",
+        "九": "9",
+    }
+)
+_INTENT_RE = re.compile(
+    r"(?:^|[\s，。；！,;!])"
+    r"我(?:来|帮(?:您|你))?按(?:一下|下)?(?:键)?\s*"
+    r"(?P<digits>(?:[0-9零〇一二三四五六七八九幺两#*]|井号|星号|\s)+)"
+)
+_BLOCKED_RE = re.compile(
+    r"[?？]|(?:吗|么|吧|是否|是不是|要不要)\s*[?？。！]?$|"
+    r"(?:不|没|没有|还没|别|不用|不要)\s*(?:来|帮(?:您|你))?按|"
+    r"我(?:来|帮(?:您|你))?按(?:错|错了)|"
+    r"(?:如果|要是|假如|除非|还是|或者|或是)|"
+    r"(?<!帮)(?:您按|你按)|"
+    r"(?:请按|他说|她说|它说|对方说|客服说|系统说|系统提示|菜单说|播报|原话|复述)"
+)
+
+
+def extract_spoken_dtmf(text: str) -> str | None:
+    """Return a legal DTMF sequence from a narrow affirmative self-statement.
+
+    The guard deliberately rejects questions, negation, conditions and quoted
+    menu wording. It executes an action the Agent says it is taking; it does not
+    interpret the remote party's IVR menu.
+    """
+
+    normalized = " ".join(str(text or "").strip().split())
+    if not normalized or _BLOCKED_RE.search(normalized):
+        return None
+    match = _INTENT_RE.search(normalized)
+    if match is None:
+        return None
+    raw = match.group("digits").replace("井号", "#").replace("星号", "*")
+    digits = re.sub(r"\s+", "", raw).translate(_DIGIT_MAP)
+    if not re.fullmatch(r"[0-9*#]{1,32}", digits):
+        return None
+    return digits

--- a/src/agentcall/number_profiles.py
+++ b/src/agentcall/number_profiles.py
@@ -15,6 +15,9 @@ prefer supplying both languages for every field to avoid mixed-language output.
 ``opening_mode``(#80-B,可选): ``say``(默认)拨通即说开场白;``wait``
 静默等对方先说——IVR 热线(如运营商客服)用,避免 AI 开场白压掉首段菜单
 播报。语言无关的普通字符串;非法值按 ``say`` 处理。
+
+``dtmf_spoken_followup``(可选): 默认 ``false``。仅对显式启用的 IVR
+profile，在 Agent 明确说出自己将按键却未调用工具时启用执行层安全网。
 """
 
 from __future__ import annotations
@@ -54,6 +57,7 @@ _MANAGED_FIELDS = {
     "scenario",
     "opening",
     "opening_mode",
+    "dtmf_spoken_followup",
 }
 
 
@@ -364,6 +368,7 @@ def _normalize_profile(
         "scenario": scenario,
         "opening": opening,
         "opening_mode": opening_mode,
+        "dtmf_spoken_followup": item.get("dtmf_spoken_followup") is True,
         "error": None,
         "provider": "",
         "model": "",
@@ -430,6 +435,7 @@ def _managed_profile(item: dict[str, Any], profile_id: str) -> dict[str, Any]:
         "scenario": _localized_map(item.get("scenario")),
         "opening": _localized_map(item.get("opening")),
         "opening_mode": opening_mode,
+        "dtmf_spoken_followup": item.get("dtmf_spoken_followup") is True,
     }
 
 
@@ -468,6 +474,9 @@ def _validate_profile_payload(payload: Any) -> dict[str, Any]:
         raise ProfileValidationError("opening_mode 只能是 say 或 wait")
     if not opening_mode:
         opening_mode = "say"
+    dtmf_spoken_followup = payload.get("dtmf_spoken_followup", False)
+    if not isinstance(dtmf_spoken_followup, bool):
+        raise ProfileValidationError("dtmf_spoken_followup 必须是布尔值")
 
     profile: dict[str, Any] = {
         "enabled": enabled,
@@ -476,6 +485,7 @@ def _validate_profile_payload(payload: Any) -> dict[str, Any]:
         "scenario": scenario,
         "opening": opening,
         "opening_mode": opening_mode,
+        "dtmf_spoken_followup": dtmf_spoken_followup,
     }
     if match_mode == "exact":
         profile["task"] = task

--- a/src/agentcall/web/static/index.html
+++ b/src/agentcall/web/static/index.html
@@ -941,6 +941,13 @@
                       <option value="wait" data-i18n="profile_opening_mode_wait"></option>
                     </select>
                   </div>
+                  <div class="profile-enabled-field">
+                    <span class="profile-switch-label" id="profileDtmfSpokenFollowupLabel" data-i18n="profile_dtmf_spoken_followup"></span>
+                    <label class="switch" for="profileDtmfSpokenFollowup">
+                      <input id="profileDtmfSpokenFollowup" type="checkbox" aria-labelledby="profileDtmfSpokenFollowupLabel" />
+                      <span class="knob"></span>
+                    </label>
+                  </div>
                 </div>
                 <div class="profile-languages">
                   <fieldset class="profile-language">
@@ -1218,7 +1225,7 @@ const I18N = {
     profile_number: "Phone number", profile_match: "Match rule", profile_exact: "Exact task", profile_number_default: "Number fallback",
     profile_enabled: "Enabled", profile_lang_zh: "CHINESE", profile_lang_en: "ENGLISH",
     profile_label: "Dropdown label", profile_task: "Matching task", profile_scenario: "Scenario strategy", profile_opening: "First sentence",
-    profile_opening_mode: "Opening mode", profile_opening_mode_say: "Say immediately (default)", profile_opening_mode_wait: "Wait for IVR menu",
+    profile_opening_mode: "Opening mode", profile_opening_mode_say: "Say immediately (default)", profile_opening_mode_wait: "Wait for IVR menu", profile_dtmf_spoken_followup: "Recover spoken keypress",
     profile_save: "Save", profile_cancel: "Cancel", profile_duplicate: "Duplicate", profile_delete: "Delete",
     profile_saving: "Saving…", profile_saved: "Preset saved", profile_deleted: "Preset deleted",
     profile_need_number: "Enter a dialable phone number.", profile_need_scenario: "Add a scenario strategy in at least one language.",
@@ -1387,7 +1394,7 @@ const I18N = {
     profile_number: "电话号码", profile_match: "匹配规则", profile_exact: "号码+任务", profile_number_default: "号码通配",
     profile_enabled: "启用本条", profile_lang_zh: "中文", profile_lang_en: "英文",
     profile_label: "下拉显示名称", profile_task: "匹配任务", profile_scenario: "场景策略", profile_opening: "第一句话",
-    profile_opening_mode: "开场模式", profile_opening_mode_say: "直接说开场白（默认）", profile_opening_mode_wait: "等待 IVR 菜单播报",
+    profile_opening_mode: "开场模式", profile_opening_mode_say: "直接说开场白（默认）", profile_opening_mode_wait: "等待 IVR 菜单播报", profile_dtmf_spoken_followup: "补发已口述按键",
     profile_save: "保存", profile_cancel: "取消", profile_duplicate: "复制", profile_delete: "删除",
     profile_saving: "保存中…", profile_saved: "预设已保存", profile_deleted: "预设已删除",
     profile_need_number: "请输入可以拨打的电话号码。", profile_need_scenario: "请至少填写一种语言的场景策略。",
@@ -1852,7 +1859,7 @@ function blankManagedProfile() {
   return {
     id: "", enabled: true, number: "", match_mode: "exact",
     label: { ...blank }, task: { ...blank }, scenario: { ...blank }, opening: { ...blank },
-    opening_mode: "say",
+    opening_mode: "say", dtmf_spoken_followup: false,
   };
 }
 
@@ -1942,6 +1949,7 @@ function openProfileEditor(profile) {
   }
   setProfileMatchMode(item.match_mode || "exact");
   $("profileOpeningMode").value = (item.opening_mode === "wait" ? "wait" : "say");
+  $("profileDtmfSpokenFollowup").checked = item.dtmf_spoken_followup === true;
   $("profileDelete").hidden = !item.id;
   $("profileToast").className = "toast profile-toast";
   $("profileToast").textContent = "";
@@ -1968,6 +1976,7 @@ function readProfileForm() {
     scenario: { zh: $("profileScenarioZh").value.trim(), en: $("profileScenarioEn").value.trim() },
     opening: { zh: $("profileOpeningZh").value.trim(), en: $("profileOpeningEn").value.trim() },
     opening_mode: $("profileOpeningMode").value,
+    dtmf_spoken_followup: $("profileDtmfSpokenFollowup").checked,
   };
 }
 

--- a/tests/unit/test_dtmf_spoken_followup.py
+++ b/tests/unit/test_dtmf_spoken_followup.py
@@ -1,0 +1,296 @@
+"""Spoken DTMF fallback parsing and call-session orchestration."""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+from fakes import FakeAgent, FakeAudioBridge, FakeModem
+
+from agentcall.call_agent import CallAgentService
+from agentcall.dtmf_followup import extract_spoken_dtmf
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("我按1。", "1"),
+        ("好的，我来按一", "1"),
+        ("我帮您按幺零三#", "103#"),
+        ("我帮你按103#进入下一步", "103#"),
+        ("我按*9#", "*9#"),
+        ("我按井号", "#"),
+        ("我按星号", "*"),
+    ],
+)
+def test_extract_spoken_dtmf_accepts_first_person_affirmative_statements(
+    text, expected
+):
+    assert extract_spoken_dtmf(text) == expected
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "您按1就可以了",
+        "请按1",
+        "我按1吗？",
+        "我按1吧",
+        "我按1还是2",
+        "我不按1",
+        "我还没按1",
+        "我按错了1",
+        "如果需要，我按1",
+        "系统提示请按1，我按1",
+        "他说我按1就可以",
+        "对方说‘我按1’",
+        "我只是复述：我按1",
+        "我按十",
+        "我按A",
+    ],
+)
+def test_extract_spoken_dtmf_rejects_questions_negation_conditions_and_quotes(text):
+    assert extract_spoken_dtmf(text) is None
+
+
+class _ExternalResultAgent(FakeAgent):
+    def __init__(self, *, accept_external_result: bool = True) -> None:
+        super().__init__()
+        self.accept_external_result = accept_external_result
+        self.external_results: list[tuple[str, dict, str]] = []
+
+    async def external_tool_result(
+        self, name: str, result: dict, *, source: str
+    ) -> bool:
+        self.external_results.append((name, result, source))
+        return self.accept_external_result
+
+
+class _SpyCallRecord:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict]] = []
+
+    def log_event(self, event_type: str, **fields) -> None:
+        self.events.append((event_type, fields))
+
+    def write_downlink(self, _pcm: bytes) -> None:
+        pass
+
+    def write_uplink(self, _pcm: bytes) -> None:
+        pass
+
+    def finish(self, **_kwargs) -> None:
+        pass
+
+
+def _start_profile_call(
+    monkeypatch,
+    tmp_path,
+    *,
+    followup: bool,
+    accept_external_result: bool = True,
+    delay: float = 0.05,
+):
+    profile_file = tmp_path / "number_profiles.json"
+    profile_file.write_text(
+        json.dumps(
+            {
+                "profiles": [
+                    {
+                        "number": "10086",
+                        "scenario": "IVR hotline",
+                        "opening_mode": "wait",
+                        "dtmf_spoken_followup": followup,
+                    }
+                ]
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("NUMBER_PROFILES_ENABLED", "true")
+    monkeypatch.setenv("NUMBER_PROFILES_FILE", str(profile_file))
+    monkeypatch.setenv("PROMPT_GEN_ENABLED", "false")
+    monkeypatch.setattr(
+        "agentcall.call_agent.DTMF_SPOKEN_FOLLOWUP_DELAY_SECONDS", delay
+    )
+
+    modem = FakeModem()
+    bridge = FakeAudioBridge()
+    agent = _ExternalResultAgent(accept_external_result=accept_external_result)
+    record = _SpyCallRecord()
+    monkeypatch.setattr("agentcall.call_agent.create_audio_bridge", lambda **_kw: bridge)
+    monkeypatch.setattr("agentcall.call_agent.create_agent", lambda _provider: agent)
+    monkeypatch.setattr(
+        "agentcall.call_agent.CallSession._begin_record",
+        lambda _self, _direction, _number: record,
+    )
+
+    service = CallAgentService(
+        modem_port="unused",
+        audio_keyword="unused",
+        provider="qwen",
+        audio_mode="nmea",
+        modem=modem,  # type: ignore[arg-type]
+    )
+    ok, error = service.dial("10086")
+    assert ok, error
+    deadline = time.monotonic() + 3
+    while time.monotonic() < deadline and ("dial", ("10086",)) not in modem.calls:
+        time.sleep(0.01)
+    modem.trigger_call_connected("10086")
+    deadline = time.monotonic() + 3
+    while time.monotonic() < deadline and not agent.started:
+        time.sleep(0.01)
+    assert agent.started
+    return service, modem, agent, record
+
+
+def _stop_profile_call(service: CallAgentService) -> None:
+    service.session.stop()
+    assert service.session._thread is not None
+    service.session._thread.join(timeout=3)
+
+
+def _dtmf_calls(modem: FakeModem) -> list[tuple[str, tuple]]:
+    return [call for call in modem.calls if call[0] == "send_dtmf"]
+
+
+def test_spoken_followup_dispatches_multi_digit_once_and_injects_result(
+    monkeypatch, tmp_path
+):
+    service, modem, agent, record = _start_profile_call(
+        monkeypatch, tmp_path, followup=True
+    )
+    try:
+        agent._emit_transcript("agent", "好的，我帮您按幺零三#")
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline and not _dtmf_calls(modem):
+            time.sleep(0.01)
+
+        assert _dtmf_calls(modem) == [("send_dtmf", ("103#",))]
+        assert len(agent.external_results) == 1
+        name, result, source = agent.external_results[0]
+        assert name == "send_dtmf"
+        assert result["success"] is True
+        assert result["count"] == 4
+        assert source == "spoken_followup"
+
+        events = [fields for kind, fields in record.events if kind == "dtmf_auto_followup"]
+        assert len(events) == 1
+        assert events[0]["count"] == 4
+        assert events[0]["mode"] == "qvts"
+        assert events[0]["result"] == "success"
+        assert events[0]["source"] == "agent_transcript"
+        assert "digit" not in events[0] and "digits" not in events[0]
+    finally:
+        _stop_profile_call(service)
+
+
+def test_spoken_followup_is_disabled_without_profile_opt_in(monkeypatch, tmp_path):
+    service, modem, agent, _record = _start_profile_call(
+        monkeypatch, tmp_path, followup=False
+    )
+    try:
+        agent._emit_transcript("agent", "我按1")
+        time.sleep(0.15)
+        assert _dtmf_calls(modem) == []
+        assert agent.external_results == []
+    finally:
+        _stop_profile_call(service)
+
+
+def test_real_tool_before_timer_cancels_spoken_followup(monkeypatch, tmp_path):
+    service, modem, agent, _record = _start_profile_call(
+        monkeypatch, tmp_path, followup=True, delay=0.15
+    )
+    try:
+        agent._emit_transcript("agent", "我按1")
+        assert agent._tools is not None
+        result = agent._tools.dispatch("send_dtmf", {"digits": "1"})
+        assert result["success"] is True
+        time.sleep(0.25)
+        assert _dtmf_calls(modem) == [("send_dtmf", ("1",))]
+        assert agent.external_results == []
+    finally:
+        _stop_profile_call(service)
+
+
+def test_real_tool_before_transcript_prevents_spoken_followup(monkeypatch, tmp_path):
+    service, modem, agent, _record = _start_profile_call(
+        monkeypatch, tmp_path, followup=True, delay=0.1
+    )
+    try:
+        assert agent._tools is not None
+        result = agent._tools.dispatch("send_dtmf", {"digits": "1"})
+        assert result["success"] is True
+        agent._emit_transcript("agent", "我按1")
+        time.sleep(0.2)
+        assert _dtmf_calls(modem) == [("send_dtmf", ("1",))]
+        assert agent.external_results == []
+    finally:
+        _stop_profile_call(service)
+
+
+def test_real_tool_after_auto_followup_is_deduplicated(monkeypatch, tmp_path):
+    service, modem, agent, _record = _start_profile_call(
+        monkeypatch, tmp_path, followup=True
+    )
+    try:
+        agent._emit_transcript("agent", "我按1")
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline and not _dtmf_calls(modem):
+            time.sleep(0.01)
+        assert agent._tools is not None
+        result = agent._tools.dispatch("send_dtmf", {"digits": "1"})
+        assert result["success"] is True
+        assert _dtmf_calls(modem) == [("send_dtmf", ("1",))]
+    finally:
+        _stop_profile_call(service)
+
+
+def test_two_genuine_tool_calls_are_not_deduplicated(monkeypatch, tmp_path):
+    service, modem, agent, _record = _start_profile_call(
+        monkeypatch, tmp_path, followup=True
+    )
+    try:
+        assert agent._tools is not None
+        first = agent._tools.dispatch("send_dtmf", {"digits": "1"})
+        second = agent._tools.dispatch("send_dtmf", {"digits": "1"})
+        assert first["success"] is True and second["success"] is True
+        assert _dtmf_calls(modem) == [
+            ("send_dtmf", ("1",)),
+            ("send_dtmf", ("1",)),
+        ]
+    finally:
+        _stop_profile_call(service)
+
+
+def test_external_result_rejection_does_not_repeat_or_kill_call(monkeypatch, tmp_path):
+    service, modem, agent, _record = _start_profile_call(
+        monkeypatch,
+        tmp_path,
+        followup=True,
+        accept_external_result=False,
+    )
+    try:
+        agent._emit_transcript("agent", "我按1")
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline and not agent.external_results:
+            time.sleep(0.01)
+        assert _dtmf_calls(modem) == [("send_dtmf", ("1",))]
+        assert service.session.is_active
+        assert len(agent.external_results) == 1
+    finally:
+        _stop_profile_call(service)
+
+
+def test_pending_spoken_followup_is_cancelled_when_call_ends(monkeypatch, tmp_path):
+    service, modem, agent, _record = _start_profile_call(
+        monkeypatch, tmp_path, followup=True, delay=0.2
+    )
+    agent._emit_transcript("agent", "我按1")
+    _stop_profile_call(service)
+    time.sleep(0.3)
+    assert _dtmf_calls(modem) == []

--- a/tests/unit/test_dtmf_spoken_followup.py
+++ b/tests/unit/test_dtmf_spoken_followup.py
@@ -84,6 +84,13 @@ class _SpyCallRecord:
         pass
 
 
+def _wait_until(condition, *, timeout: float = 2.0) -> None:
+    deadline = time.monotonic() + timeout
+    while not condition() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert condition()
+
+
 def _start_profile_call(
     monkeypatch,
     tmp_path,
@@ -139,6 +146,7 @@ def _start_profile_call(
     deadline = time.monotonic() + 3
     while time.monotonic() < deadline and ("dial", ("10086",)) not in modem.calls:
         time.sleep(0.01)
+    assert ("dial", ("10086",)) in modem.calls
     modem.trigger_call_connected("10086")
     deadline = time.monotonic() + 3
     while time.monotonic() < deadline and not agent.started:
@@ -165,9 +173,10 @@ def test_spoken_followup_dispatches_multi_digit_once_and_injects_result(
     )
     try:
         agent._emit_transcript("agent", "好的，我帮您按幺零三#")
-        deadline = time.monotonic() + 2
-        while time.monotonic() < deadline and not _dtmf_calls(modem):
-            time.sleep(0.01)
+        _wait_until(
+            lambda: len(agent.external_results) == 1
+            and any(kind == "dtmf_auto_followup" for kind, _fields in record.events)
+        )
 
         assert _dtmf_calls(modem) == [("send_dtmf", ("103#",))]
         assert len(agent.external_results) == 1
@@ -239,9 +248,7 @@ def test_real_tool_after_auto_followup_is_deduplicated(monkeypatch, tmp_path):
     )
     try:
         agent._emit_transcript("agent", "我按1")
-        deadline = time.monotonic() + 2
-        while time.monotonic() < deadline and not _dtmf_calls(modem):
-            time.sleep(0.01)
+        _wait_until(lambda: len(_dtmf_calls(modem)) == 1)
         assert agent._tools is not None
         result = agent._tools.dispatch("send_dtmf", {"digits": "1"})
         assert result["success"] is True
@@ -276,9 +283,7 @@ def test_external_result_rejection_does_not_repeat_or_kill_call(monkeypatch, tmp
     )
     try:
         agent._emit_transcript("agent", "我按1")
-        deadline = time.monotonic() + 2
-        while time.monotonic() < deadline and not agent.external_results:
-            time.sleep(0.01)
+        _wait_until(lambda: len(agent.external_results) == 1)
         assert _dtmf_calls(modem) == [("send_dtmf", ("1",))]
         assert service.session.is_active
         assert len(agent.external_results) == 1

--- a/tests/unit/test_local_agent.py
+++ b/tests/unit/test_local_agent.py
@@ -179,6 +179,25 @@ def test_send_dtmf_result_waits_for_next_utterance_without_followup_speech():
     assert pipeline.synthesized == []
 
 
+def test_external_tool_result_appends_system_fact_without_generating_speech():
+    agent = LocalPipelineAgent(pipeline_factory=FakePipeline)
+    agent._messages = [{"role": "system", "content": "base"}]
+
+    accepted = asyncio.run(
+        agent.external_tool_result(
+            "send_dtmf",
+            {"success": True, "count": 1, "mode": "qvts"},
+            source="spoken_followup",
+        )
+    )
+
+    assert accepted is True
+    assert len(agent._messages) == 2
+    assert agent._messages[-1]["role"] == "system"
+    assert "send_dtmf" in agent._messages[-1]["content"]
+    assert agent._brain_queue.empty()
+
+
 def test_llm_failures_mark_fatal():
     replies = [RuntimeError("boom"), RuntimeError("boom"), RuntimeError("boom")]
     agent, _pipeline, _seen = _make_agent(replies)

--- a/tests/unit/test_number_profiles.py
+++ b/tests/unit/test_number_profiles.py
@@ -535,3 +535,54 @@ def test_bundled_seed_china_mobile_ivr_has_opening_mode_wait():
             break
     else:
         pytest.fail("seed 中未找到 china_mobile_data")
+
+
+def test_dtmf_spoken_followup_defaults_false_and_roundtrips(tmp_path):
+    path = tmp_path / "number_profiles.json"
+    path.write_text(
+        json.dumps(
+            {"profiles": [{"number": "10000", "scenario": "default"}]},
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    assert number_profiles.lookup_profile("10000", "", path=path)[
+        "dtmf_spoken_followup"
+    ] is False
+
+    created = number_profiles.create_profile(
+        {
+            "number": "10086",
+            "scenario": {"zh": "IVR"},
+            "match_mode": "number",
+            "dtmf_spoken_followup": True,
+        },
+        path=path,
+    )
+    assert created["dtmf_spoken_followup"] is True
+    assert number_profiles.lookup_profile("10086", "", path=path)[
+        "dtmf_spoken_followup"
+    ] is True
+
+
+def test_dtmf_spoken_followup_rejects_non_boolean(tmp_path):
+    with pytest.raises(number_profiles.ProfileValidationError, match="dtmf_spoken_followup"):
+        number_profiles.create_profile(
+            {
+                "number": "10086",
+                "scenario": "IVR",
+                "match_mode": "number",
+                "dtmf_spoken_followup": "true",
+            },
+            path=tmp_path / "number_profiles.json",
+        )
+
+
+def test_bundled_seed_only_enables_spoken_followup_for_10086():
+    data = json.loads(number_profiles.bundled_seed_file().read_text(encoding="utf-8"))
+    enabled = [
+        item.get("number")
+        for item in data["profiles"]
+        if item.get("dtmf_spoken_followup") is True
+    ]
+    assert enabled == ["10086"]

--- a/tests/unit/test_openai_agent.py
+++ b/tests/unit/test_openai_agent.py
@@ -500,6 +500,36 @@ def test_send_dtmf_result_waits_for_next_ivr_without_response_create(monkeypatch
     assert "response.create" not in ws.sent_types()
 
 
+def test_external_tool_result_adds_system_fact_without_fake_call_or_response(monkeypatch):
+    instances, _calls = _patch_connect(monkeypatch)
+    agent = _make_agent()
+
+    async def scenario():
+        await agent.start(lambda pcm: None)
+        try:
+            accepted = await agent.external_tool_result(
+                "send_dtmf",
+                {"success": True, "count": 4, "mode": "inband"},
+                source="spoken_followup",
+            )
+            assert accepted is True
+        finally:
+            await agent.stop()
+
+    asyncio.run(scenario())
+
+    ws = instances[0]
+    created = [item for item in ws.sent if item["type"] == "conversation.item.create"]
+    assert len(created) == 1
+    item = created[0]["item"]
+    assert item["type"] == "message"
+    assert item["role"] == "system"
+    assert item["content"][0]["type"] == "input_text"
+    assert "send_dtmf" in item["content"][0]["text"]
+    assert "call_id" not in item
+    assert "response.create" not in ws.sent_types()
+
+
 def test_tool_result_dropped_when_connection_replaced(monkeypatch):
     """工具执行期间断线重连：旧 call_id 的结果不得发进新会话（codex review P1）。"""
     import threading

--- a/tests/unit/test_openai_agent.py
+++ b/tests/unit/test_openai_agent.py
@@ -173,6 +173,160 @@ def test_session_instructions_override_default(monkeypatch):
     asyncio.run(scenario())
 
 
+def test_manual_response_control_sets_create_response_false_and_debounces(monkeypatch):
+    monkeypatch.setenv("MANUAL_RESPONSE_CONTROL", "true")
+    monkeypatch.setenv("MANUAL_RESPONSE_SILENCE_MS", "25")
+    monkeypatch.setenv("MANUAL_RESPONSE_MAX_WAIT_MS", "500")
+    instances, _calls = _patch_connect(monkeypatch)
+    agent = _make_agent()
+
+    async def scenario():
+        await agent.start(lambda pcm: None)
+        try:
+            ws = instances[0]
+            turn_detection = ws.sent[0]["session"]["audio"]["input"]["turn_detection"]
+            assert turn_detection == {"type": "server_vad", "create_response": False}
+            for text in ("第一段菜单", "第二段菜单", "第三段菜单"):
+                ws.feed(
+                    {
+                        "type": "conversation.item.input_audio_transcription.completed",
+                        "transcript": text,
+                    }
+                )
+                await asyncio.sleep(0.01)
+            await asyncio.sleep(0.08)
+            creates = [item for item in ws.sent if item["type"] == "response.create"]
+            assert creates == [{"type": "response.create"}]
+        finally:
+            await agent.stop()
+
+    asyncio.run(scenario())
+
+
+def test_manual_response_control_waits_for_active_response_done(monkeypatch):
+    monkeypatch.setenv("MANUAL_RESPONSE_CONTROL", "true")
+    monkeypatch.setenv("MANUAL_RESPONSE_SILENCE_MS", "20")
+    monkeypatch.setenv("MANUAL_RESPONSE_MAX_WAIT_MS", "500")
+    instances, _calls = _patch_connect(monkeypatch)
+    agent = _make_agent()
+
+    async def scenario():
+        await agent.start(lambda pcm: None)
+        try:
+            ws = instances[0]
+            ws.feed({"type": "response.created", "response": {"id": "r1"}})
+            ws.feed(
+                {
+                    "type": "conversation.item.input_audio_transcription.completed",
+                    "transcript": "AI 说话期间 IVR 继续播报",
+                }
+            )
+            await _drain()
+            await asyncio.sleep(0.05)
+            assert "response.create" not in ws.sent_types()
+
+            ws.feed({"type": "response.done", "response": {"id": "r1"}})
+            await _drain()
+            await asyncio.sleep(0.05)
+            assert ws.sent_types().count("response.create") == 1
+        finally:
+            await agent.stop()
+
+    asyncio.run(scenario())
+
+
+def test_manual_response_control_stop_cancels_pending_timer(monkeypatch):
+    monkeypatch.setenv("MANUAL_RESPONSE_CONTROL", "true")
+    monkeypatch.setenv("MANUAL_RESPONSE_SILENCE_MS", "80")
+    monkeypatch.setenv("MANUAL_RESPONSE_MAX_WAIT_MS", "500")
+    instances, _calls = _patch_connect(monkeypatch)
+    agent = _make_agent()
+
+    async def scenario():
+        await agent.start(lambda pcm: None)
+        ws = instances[0]
+        ws.feed(
+            {
+                "type": "conversation.item.input_audio_transcription.completed",
+                "transcript": "稍后才该回复",
+            }
+        )
+        await _drain()
+        await agent.stop()
+        await asyncio.sleep(0.12)
+        assert "response.create" not in ws.sent_types()
+
+    asyncio.run(scenario())
+
+
+def test_manual_response_control_request_watchdog_recovers_missing_created(
+    monkeypatch,
+):
+    monkeypatch.setenv("MANUAL_RESPONSE_CONTROL", "true")
+    monkeypatch.setenv("MANUAL_RESPONSE_SILENCE_MS", "15")
+    monkeypatch.setenv("MANUAL_RESPONSE_MAX_WAIT_MS", "0")
+    monkeypatch.setattr(
+        openai_agent, "_MANUAL_RESPONSE_CREATED_TIMEOUT_SECONDS", 0.04
+    )
+    instances, _calls = _patch_connect(monkeypatch)
+    agent = _make_agent()
+
+    async def scenario():
+        await agent.start(lambda pcm: None)
+        try:
+            ws = instances[0]
+            ws.feed(
+                {
+                    "type": "conversation.item.input_audio_transcription.completed",
+                    "transcript": "第一段播报",
+                }
+            )
+            await _drain()
+            await asyncio.sleep(0.03)
+            assert ws.sent_types().count("response.create") == 1
+
+            ws.feed(
+                {
+                    "type": "conversation.item.input_audio_transcription.completed",
+                    "transcript": "created 丢失后的新播报",
+                }
+            )
+            await _drain()
+            await asyncio.sleep(0.08)
+            assert ws.sent_types().count("response.create") == 2
+        finally:
+            await agent.stop()
+
+    asyncio.run(scenario())
+
+
+def test_manual_response_control_max_wait_forces_response(monkeypatch):
+    monkeypatch.setenv("MANUAL_RESPONSE_CONTROL", "true")
+    monkeypatch.setenv("MANUAL_RESPONSE_SILENCE_MS", "1000")
+    monkeypatch.setenv("MANUAL_RESPONSE_MAX_WAIT_MS", "45")
+    instances, _calls = _patch_connect(monkeypatch)
+    agent = _make_agent()
+
+    async def scenario():
+        await agent.start(lambda pcm: None)
+        try:
+            ws = instances[0]
+            for index in range(5):
+                ws.feed(
+                    {
+                        "type": "conversation.item.input_audio_transcription.completed",
+                        "transcript": f"连续播报 {index}",
+                    }
+                )
+                await asyncio.sleep(0.01)
+            await asyncio.sleep(0.06)
+            assert ws.sent_types().count("response.create") == 1
+        finally:
+            await agent.stop()
+
+    asyncio.run(scenario())
+
+
 def test_realtime_url_override(monkeypatch):
     """OPENAI_REALTIME_URL 覆盖 base（反向代理/Azure 兼容端点）。"""
     _instances, calls = _patch_connect(monkeypatch)

--- a/tests/unit/test_openai_agent.py
+++ b/tests/unit/test_openai_agent.py
@@ -95,6 +95,22 @@ async def _drain() -> None:
         await asyncio.sleep(0)
 
 
+async def _wait_for_sent_count(
+    ws: _FakeWs,
+    event_type: str,
+    expected: int,
+    *,
+    timeout: float = 2.0,
+) -> None:
+    """Wait for timer-thread work without assuming runner scheduling speed."""
+
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while ws.sent_types().count(event_type) < expected and loop.time() < deadline:
+        await asyncio.sleep(0.01)
+    assert ws.sent_types().count(event_type) == expected
+
+
 # ---------------------------------------------------------------------------
 # 连接与 session.update
 # ---------------------------------------------------------------------------
@@ -194,7 +210,7 @@ def test_manual_response_control_sets_create_response_false_and_debounces(monkey
                     }
                 )
                 await asyncio.sleep(0.01)
-            await asyncio.sleep(0.08)
+            await _wait_for_sent_count(ws, "response.create", 1)
             creates = [item for item in ws.sent if item["type"] == "response.create"]
             assert creates == [{"type": "response.create"}]
         finally:
@@ -227,8 +243,7 @@ def test_manual_response_control_waits_for_active_response_done(monkeypatch):
 
             ws.feed({"type": "response.done", "response": {"id": "r1"}})
             await _drain()
-            await asyncio.sleep(0.05)
-            assert ws.sent_types().count("response.create") == 1
+            await _wait_for_sent_count(ws, "response.create", 1)
         finally:
             await agent.stop()
 
@@ -282,8 +297,7 @@ def test_manual_response_control_request_watchdog_recovers_missing_created(
                 }
             )
             await _drain()
-            await asyncio.sleep(0.03)
-            assert ws.sent_types().count("response.create") == 1
+            await _wait_for_sent_count(ws, "response.create", 1)
 
             ws.feed(
                 {
@@ -292,8 +306,7 @@ def test_manual_response_control_request_watchdog_recovers_missing_created(
                 }
             )
             await _drain()
-            await asyncio.sleep(0.08)
-            assert ws.sent_types().count("response.create") == 2
+            await _wait_for_sent_count(ws, "response.create", 2)
         finally:
             await agent.stop()
 
@@ -319,8 +332,7 @@ def test_manual_response_control_max_wait_forces_response(monkeypatch):
                     }
                 )
                 await asyncio.sleep(0.01)
-            await asyncio.sleep(0.06)
-            assert ws.sent_types().count("response.create") == 1
+            await _wait_for_sent_count(ws, "response.create", 1)
         finally:
             await agent.stop()
 

--- a/tests/unit/test_qwen_agent.py
+++ b/tests/unit/test_qwen_agent.py
@@ -198,6 +198,31 @@ def test_manual_response_control_off_keeps_session_and_completed_path(monkeypatc
         asyncio.run(agent.stop())
 
 
+def test_session_updated_logs_manual_response_ack_without_session_payload(
+    monkeypatch, caplog
+):
+    monkeypatch.setenv("MANUAL_RESPONSE_CONTROL", "true")
+    fake_cls = _make_fake_conversation_cls()
+    agent = _start_agent(monkeypatch, fake_cls)
+    try:
+        with caplog.at_level(logging.INFO, logger="agentcall.agents.qwen_agent"):
+            agent._callback.on_event(
+                {
+                    "type": "session.updated",
+                    "session": {
+                        "turn_detection": {"create_response": False},
+                        "instructions": "private profile content",
+                    },
+                }
+            )
+        assert "session.updated" in caplog.text
+        assert "manual_response_requested=True" in caplog.text
+        assert "create_response=False" in caplog.text
+        assert "private profile content" not in caplog.text
+    finally:
+        asyncio.run(agent.stop())
+
+
 def test_manual_response_control_debounces_completed_events(monkeypatch):
     monkeypatch.setenv("MANUAL_RESPONSE_CONTROL", "true")
     monkeypatch.setenv("MANUAL_RESPONSE_SILENCE_MS", "30")

--- a/tests/unit/test_web_static.py
+++ b/tests/unit/test_web_static.py
@@ -151,6 +151,9 @@ def test_profile_manager_has_crud_controls_and_safe_rendering():
     assert 'opening_mode: "say"' in text    # blankManagedProfile 默认
     assert 'opening_mode: $("profileOpeningMode").value' in text  # readProfileForm
     assert '$("profileOpeningMode").value' in text  # openProfileEditor set
+    assert 'id="profileDtmfSpokenFollowup"' in text
+    assert "dtmf_spoken_followup: false" in text
+    assert 'dtmf_spoken_followup: $("profileDtmfSpokenFollowup").checked' in text
 
 
 def test_manual_dial_requires_explicit_task_or_selected_preset():


### PR DESCRIPTION
## Spoken DTMF recovery guard + Realtime MRC parity

P2 真机(10000 电信卡)实测暴露:realtime 模型常口播"我按X"却不真调 send_dtmf(实测 12 次按键:口播 9 / 无反应 3 / 真调 2)。提示词层已到顶。本 PR 落地三方共识的**执行层守护** + 修 A/B 实验有效性。两 commit 线性拆分。

### 1. Spoken DTMF recovery guard (e5a9d24)
agent 完成转写中出现**第一人称肯定式**按键声明(我按/我来按/我帮您按 + digit),3s 内无对应真实 send_dtmf → 补发。
- **默认关 + profile opt-in**(`dtmf_spoken_followup:true` 或预设 UI 勾选;seed 仅 10086=true)——防误导航触发不可逆菜单;
- 窄匹配:多位/中文数字/井号星号;**拒绝**疑问/否定/"按错"/条件/"您按"/复述引用;
- **execute/notify 两层不孤儿化**:执行走完整 `send_dtmf` dispatch;上下文通知经 `VoiceAgent.external_tool_result`——OpenAI/local 写 `system message`(非 function_call_output、**无伪造 call_id**、零 create_response),Qwen 基类降级 `return False`(只 dispatch+审计);
- **双向去重**:auto↔真实 5s 去重,真实↔真实不误杀;
- **worker 线程** dispatch,qvts AT 不阻塞音频 loop;
- 事件 `dtmf_auto_followup` 仅 count/mode/result/delay/source/context_injected,**不落 digit**(#53 红线)。

### 2. Realtime MRC parity (a56c56b)
- **OpenAI provider 补 MANUAL_RESPONSE_CONTROL 对齐**(server_vad `create_response=false` + silence/watchdog/断线停止,与 Qwen 同语义)——此前 OpenAI 无 MRC,导致 Qwen/OpenAI A/B 对照混入不同轮次策略;
- Qwen `session.updated` 记录 `manual_response_requested/create_response` 安全字段(不打印 session payload)。

### 诚实边界
- **这不是 #80-E**(=AGENT_UPLINK_GAIN,见 PR #84);是 P2 讨论出的独立执行层守护;
- 守护是 **safety net**:覆盖"口播未调工具",**覆盖不了"完全无反应"**——后者由后续**文本判官(shadow→接管)**解决,本 PR 不含判官;
- **Qwen `create_response=false` 服务端是否真采纳仍需真机核 `session.updated`**(本 PR 加了记录,留真机窗口验证);
- 口播守护真机验证需 c-2 在预设勾选/写 `dtmf_spoken_followup:true`(现有 `data/number_profiles.json` 不被 seed 覆盖)。

### 验证(cc 独立 worktree 隔离,亲核非听报告)
- pytest **840 passed / 3 skipped**;ruff 全绿;mypy 42 files clean;敏感扫描 4 pattern clean;
- 七条红线逐条亲核(匹配正则/不孤儿化 item type/双向去重 source 语义/不落 digit/worker 线程/profile 默认 false/parity 两点)。

建议 **squash merge**;合并到公开 main 需人工审批。`Refs #80`(判官 + 真机 P2 未完,不 Closes)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
