### PR TITLE
feat: 来电待办 INBOUND_PENDING_TOPIC——AI 接相关方来电时主动代问

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,8 @@ VOICE_STYLE=
 AGENT_LANGUAGE=zh
 # 外呼默认任务指令（单次外呼可在页面临时覆盖）
 AGENT_OUTBOUND_TASK=代表机主主动外呼，对方接起后自然说明来意，并围绕本次目的简短沟通。
+# 来电待办：非空时 AI 接听相关方来电会主动代机主问清这些事项（默认空=纯接待）
+INBOUND_PENDING_TOPIC=
 # 拨号前按号码+事项生成本通场景与开场策略（默认 true；失败自动回退模板）
 PROMPT_GEN_ENABLED=true
 # 动态场景提示词模型：留空=按提供方默认（qwen→qwen-plus，openai→gpt-4o-mini）

--- a/src/agentcall/config.py
+++ b/src/agentcall/config.py
@@ -193,6 +193,8 @@ CONFIG_SPECS: tuple[ConfigSpec, ...] = (
     # 默认留空 = 无预设事项（提示词走「无预设」优雅分支，不会硬塞元指令当主题）；
     # 外呼时通常在页面临时填具体主题。
     ConfigSpec("AGENT_OUTBOUND_TASK", "外呼任务指令", "str", ""),
+    # 来电待办：非空时，AI 接听相关方来电会主动代机主问清这些事项（默认空=纯接待）。
+    ConfigSpec("INBOUND_PENDING_TOPIC", "来电待办事项", "str", ""),
     ConfigSpec("PROMPT_GEN_ENABLED", "动态场景提示词", "bool", "true"),
     ConfigSpec("PROMPT_GEN_MODEL", "动态场景提示词模型", "str", ""),
     ConfigSpec("PROMPT_GEN_TIMEOUT", "动态场景提示词超时（秒）", "float", "5.0",

--- a/src/agentcall/prompts.py
+++ b/src/agentcall/prompts.py
@@ -160,12 +160,22 @@ def _build_zh(
             + common
         )
 
+    pending = config.get_str("INBOUND_PENDING_TOPIC").strip()
+    pending_line = (
+        f"待办事项：如果来电方是{pending}相关的一方（如对应的机构/客服），"
+        f"在自然接待、确认对方身份后，主动代{owner}把下面的事项问清楚、听取答复并记下要点：\n"
+        f"{pending}\n"
+        "若来电与此事项无关，按常规接待处理即可，不要生硬提起。\n"
+        if pending
+        else ""
+    )
     return (
         f"你是{owner}的{persona}，正在替{owner}接听打进来的电话，"
         f"{owner}现在不方便接。\n"
         f"来电任务：自然接待，了解对方是谁、找{owner}什么事、急不急、"
         f"是否需要{owner}回拨，并记下要点转告{owner}。\n"
-        "来电规则：\n"
+        + pending_line
+        + "来电规则：\n"
         f"1. 不要冒充{owner}本人；被问身份时说你是{owner}的{persona}。\n"
         f"2. 不要暗示是{owner}主动联系对方。\n"
         f"3. 不承诺回拨时间、不替{owner}做决定；只说会转告{owner}。\n"
@@ -298,13 +308,25 @@ def _build_en(
             + common
         )
 
+    pending = config.get_str("INBOUND_PENDING_TOPIC").strip()
+    pending_line = (
+        f"Pending matter: if the caller is a party related to [{pending}] (e.g. the "
+        f"relevant organization/agent), then after greeting and confirming who they "
+        f"are, proactively raise the following on {owner}'s behalf, get their answer, "
+        f"and note the key points:\n{pending}\n"
+        "If the call is unrelated to this matter, just handle it as a normal "
+        "reception — don't force the topic.\n"
+        if pending
+        else ""
+    )
     return (
         f"You are {owner}'s {persona}, answering an incoming call for {owner}, "
         f"who can't take it right now.\n"
         f"Task for this call: greet naturally, find out who's calling, what they "
         f"need {owner} for, how urgent it is, and whether {owner} should call back; "
         f"note the key points to pass on to {owner}.\n"
-        "Incoming-call rules:\n"
+        + pending_line
+        + "Incoming-call rules:\n"
         f"1. Never impersonate {owner} in person; when asked, say you are {owner}'s "
         f"{persona}.\n"
         f"2. Don't imply that {owner} initiated contact.\n"

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -128,6 +128,25 @@ def test_inbound_prompt_does_not_get_outbound_result_persistence():
     assert "politely steer back" not in en
 
 
+def test_inbound_pending_topic_injected_when_set(monkeypatch):
+    """设置 INBOUND_PENDING_TOPIC 后，来电提示词注入待办；默认空则不注入。"""
+    monkeypatch.setenv("INBOUND_PENDING_TOPIC", "问清某笔费用怎么产生的")
+    zh = build_instructions("inbound", "李明", "数字分身", "")
+    assert "待办事项" in zh and "问清某笔费用怎么产生的" in zh
+    en = build_instructions("inbound", "Alex", "AI assistant", "", "en")
+    assert "Pending matter" in en and "问清某笔费用怎么产生的" in en
+
+
+def test_inbound_pending_topic_absent_by_default(monkeypatch):
+    monkeypatch.delenv("INBOUND_PENDING_TOPIC", raising=False)
+    zh = build_instructions("inbound", "李明", "数字分身", "")
+    assert "待办事项" not in zh
+    # 外呼方向不注入来电待办
+    monkeypatch.setenv("INBOUND_PENDING_TOPIC", "不该出现在外呼里")
+    out = build_instructions("outbound", "李明", "数字分身", "查话费")
+    assert "不该出现在外呼里" not in out
+
+
 def test_winddown_instructions_bilingual():
     from agentcall.prompts import winddown_instructions
     assert "告别" in winddown_instructions("zh") and "再见" in winddown_instructions("zh")


### PR DESCRIPTION
新增配置项 \`INBOUND_PENDING_TOPIC\`(默认空):非空时来电提示词注入「待办事项」,AI 确认来电方身份后主动代机主问清事项并记要点;为空则纯常规接待(行为不变)。仅来电方向生效,中英双语,含 4 项单测。

用途:机构/客服回拨时 AI 主动跟进机主预置的问题(具体内容走运行时配置,不入库)。

- 全量 840 passed / ruff / mypy 绿
- Draft 待独立 review(cpair)后转正;merge 待 owner 批

Refs #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3ym8uHa4Xq46rZBDCXaDb