### PR TITLE
feat: DTMF 文本判官 Phase S(shadow)——旁观按键决策,采准确率数据

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,10 @@ MANUAL_RESPONSE_CONTROL=false
 MANUAL_RESPONSE_SILENCE_MS=1000
 # 连续播报超过该累计等待也强制触发一次回复，避免永远插不进话（默认 8000ms）
 MANUAL_RESPONSE_MAX_WAIT_MS=8000
+# DTMF 文本判官：off=关闭；shadow=只旁观并记录判断，绝不自动按键。
+DTMF_JUDGE_MODE=off
+# 留空依次回退 PROMPT_GEN_MODEL、qwen-plus（复用 DASHSCOPE_API_KEY）。
+DTMF_JUDGE_MODEL=
 
 # --- 通义千问 (DashScope) ---
 # 必填（qwen 提供方）。留空即可：占位值会骗过启动非空校验，

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ data/
 !data/
 data/*
 !data/number_profiles.example.json
+# DTMF judge cleartext analysis stays inside private per-call records.
+**/judge_shadow.jsonl
 
 # 生成的音频文件
 *.wav

--- a/scripts/regression_call.py
+++ b/scripts/regression_call.py
@@ -91,7 +91,12 @@ def extract_transcripts(events: Sequence[Event]) -> list[Transcript]:
     return transcripts
 
 
-def run_assertions(events: Sequence[Event], transcripts: Sequence[Transcript], meta: Event | None = None) -> Report:
+def run_assertions(
+    events: Sequence[Event],
+    transcripts: Sequence[Transcript],
+    meta: Event | None = None,
+    judge_shadow: Sequence[Event] = (),
+) -> Report:
     return Report(
         results=[
             check_profile_hit(events),
@@ -103,6 +108,7 @@ def run_assertions(events: Sequence[Event], transcripts: Sequence[Transcript], m
             check_dtmf_audit(events, transcripts),
             check_dtmf_followup(events),
             check_no_redundant_reask(transcripts),
+            check_dtmf_judge_shadow(events, judge_shadow),
         ]
     )
 
@@ -399,6 +405,100 @@ def check_dtmf_followup(events: Sequence[Event]) -> CheckResult:
     )
 
 
+def check_dtmf_judge_shadow(
+    events: Sequence[Event], private_entries: Sequence[Event]
+) -> CheckResult:
+    """Summarize shadow/realtime alignment without printing cleartext digits."""
+    title = "10. DTMF 判官 shadow 对齐"
+    public_decision_ids = {
+        value
+        for event in events
+        if event.get("type") == "dtmf_judge"
+        for value in [event.get("decision_id")]
+        if isinstance(value, str)
+    }
+    if not public_decision_ids:
+        return CheckResult(
+            "dtmf_judge_shadow", title, "PASS", "本通未产生 shadow 判定"
+        )
+
+    public_action_ids = {
+        value
+        for event in events
+        if event.get("type") == "dtmf_action"
+        for value in [event.get("action_id")]
+        if isinstance(value, str)
+    }
+    decisions = [
+        entry
+        for entry in private_entries
+        if entry.get("kind") == "decision"
+        and entry.get("decision_id") in public_decision_ids
+    ]
+    actions = [
+        entry
+        for entry in private_entries
+        if entry.get("kind") == "action"
+        and entry.get("action_id") in public_action_ids
+    ]
+    missing_private = len(public_decision_ids) - len(decisions)
+    press_decisions = [entry for entry in decisions if entry.get("action") == "press"]
+    exact = 0
+    mismatch = 0
+    no_action = 0
+    unused_action_ids = {
+        action_id
+        for action in actions
+        for action_id in [action.get("action_id")]
+        if isinstance(action_id, str)
+    }
+    for decision in sorted(
+        press_decisions, key=lambda item: _number(item.get("ts")) or 0.0
+    ):
+        decision_ts = _number(decision.get("ts"))
+        decision_digits = decision.get("digits")
+        if decision_ts is None or not isinstance(decision_digits, str):
+            missing_private += 1
+            continue
+        candidates = [
+            action
+            for action in actions
+            if action.get("action_id") in unused_action_ids
+            if (action_ts := _number(action.get("ts"))) is not None
+            and abs(action_ts - decision_ts) <= 5.0
+        ]
+        if not candidates:
+            no_action += 1
+            continue
+        nearest = min(
+            candidates,
+            key=lambda action: abs((_number(action.get("ts")) or 0.0) - decision_ts),
+        )
+        nearest_id = nearest.get("action_id")
+        if isinstance(nearest_id, str):
+            unused_action_ids.discard(nearest_id)
+        if nearest.get("digits") == decision_digits:
+            exact += 1
+        else:
+            mismatch += 1
+
+    modes: dict[str, int] = {}
+    for decision in decisions:
+        mode = decision.get("window_mode")
+        label = mode if isinstance(mode, str) else "unknown"
+        modes[label] = modes.get(label, 0) + 1
+    mode_detail = ",".join(f"{key}={value}" for key, value in sorted(modes.items()))
+    detail = (
+        f"decisions={len(decisions)} press={len(press_decisions)} exact={exact} "
+        f"mismatch={mismatch} no_action={no_action} missing_private={missing_private}; "
+        f"window_mode[{mode_detail or 'none'}]"
+    )
+    status: Status = (
+        "WARN" if mismatch or no_action or missing_private else "PASS"
+    )
+    return CheckResult("dtmf_judge_shadow", title, status, detail)
+
+
 def load_events(call_dir: Path) -> list[dict[str, object]]:
     path = call_dir / "events.jsonl"
     if not path.exists():
@@ -428,6 +528,29 @@ def load_meta(call_dir: Path) -> dict[str, object] | None:
     if not isinstance(meta, dict):
         raise RegressionError(f"{path} 不是 JSON object")
     return meta
+
+
+def load_judge_shadow(call_dir: Path) -> list[dict[str, object]]:
+    """Load the optional gitignored cleartext analysis file for local-only replay."""
+    path = call_dir / "judge_shadow.jsonl"
+    if not path.exists():
+        return []
+    entries: list[dict[str, object]] = []
+    for line_number, line in enumerate(
+        path.read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        if not line.strip():
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise RegressionError(
+                f"{path}:{line_number} JSON 解析失败: {exc}"
+            ) from exc
+        if not isinstance(entry, dict):
+            raise RegressionError(f"{path}:{line_number} 不是 JSON object")
+        entries.append(entry)
+    return entries
 
 
 def find_latest_recording(recordings_dir: Path = RECORDINGS_DIR) -> Path:
@@ -598,8 +721,9 @@ def main(argv: Sequence[str] | None = None) -> int:
             raise RegressionError("未找到通话录音目录")
         events = load_events(call_dir)
         meta = load_meta(call_dir)
+        judge_shadow = load_judge_shadow(call_dir)
         transcripts = extract_transcripts(events)
-        report = run_assertions(events, transcripts, meta)
+        report = run_assertions(events, transcripts, meta, judge_shadow)
         if timeout_result is not None:
             report = Report([timeout_result, *report.results])
         print_report(report, call_dir)

--- a/scripts/regression_call.py
+++ b/scripts/regression_call.py
@@ -57,6 +57,7 @@ JUDGE_REASON_CODES = frozenset(
 JUDGE_WINDOW_MODES = frozenset({"merged", "fragmented"})
 DTMF_ACTION_SOURCES = frozenset({"realtime", "judge", "guard"})
 PRIVATE_DTMF_RE = re.compile(r"^[0-9*#]+$")
+PUBLIC_PRIVATE_TS_TOLERANCE_SECONDS = 1.0
 
 
 class RegressionError(RuntimeError):
@@ -449,6 +450,10 @@ def check_dtmf_judge_shadow(
         private_entries, "action", "action_id"
     )
     schema_errors += duplicate_private_decisions + duplicate_private_actions
+    schema_errors += sum(
+        entry.get("kind") not in {"decision", "action"}
+        for entry in private_entries
+    )
 
     decisions: list[Event] = []
     seen_decision_ids: set[str] = set()
@@ -637,6 +642,8 @@ def _valid_decision_pair(public: Event, private: Event) -> bool:
         return False
     private_confidence = _number(private.get("confidence"))
     private_latency = _number(private.get("latency_ms"))
+    public_ts = _number(public.get("ts"))
+    private_ts = _number(private.get("ts"))
     reason = private.get("reason")
     return bool(
         private.get("decision_id") == public.get("decision_id")
@@ -647,7 +654,9 @@ def _valid_decision_pair(public: Event, private: Event) -> bool:
         and len(reason) <= 50
         and private_latency == latency
         and private.get("window_mode") == public.get("window_mode")
-        and _number(private.get("ts")) is not None
+        and public_ts is not None
+        and private_ts is not None
+        and abs(public_ts - private_ts) <= PUBLIC_PRIVATE_TS_TOLERANCE_SECONDS
     )
 
 
@@ -655,6 +664,8 @@ def _valid_action_pair(public: Event, private: Event) -> bool:
     source = public.get("source")
     digits_len = public.get("digits_len")
     digits = private.get("digits")
+    public_ts = _number(public.get("ts"))
+    private_ts = _number(private.get("ts"))
     return bool(
         isinstance(public.get("action_id"), str)
         and isinstance(source, str)
@@ -662,13 +673,14 @@ def _valid_action_pair(public: Event, private: Event) -> bool:
         and isinstance(digits_len, int)
         and not isinstance(digits_len, bool)
         and digits_len > 0
-        and _number(public.get("ts")) is not None
+        and public_ts is not None
         and private.get("action_id") == public.get("action_id")
         and private.get("source") == source
         and isinstance(digits, str)
         and PRIVATE_DTMF_RE.fullmatch(digits) is not None
         and private.get("digits_len") == digits_len == len(digits)
-        and _number(private.get("ts")) is not None
+        and private_ts is not None
+        and abs(public_ts - private_ts) <= PUBLIC_PRIVATE_TS_TOLERANCE_SECONDS
         and _number(private.get("t_ms")) is not None
     )
 

--- a/scripts/regression_call.py
+++ b/scripts/regression_call.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import re
 import sys
@@ -42,6 +43,20 @@ PRESS_RE = re.compile(r"我(?:来)?按(?:一下|下)?\s*[0-9一二三四五六�
 OWNER_FIELD_NAMES = ("owner", "owner_name", "ownerName", "user_name", "userName")
 DTMF_OBSERVATION_SECONDS = 8.0
 DTMF_SILENCE_GUARD_SECONDS = 3.0
+JUDGE_ACTIONS = frozenset({"press", "wait", "speak", "human", "unknown"})
+JUDGE_REASON_CODES = frozenset(
+    {
+        "menu_matched",
+        "menu_incomplete",
+        "queue_hold",
+        "human_detected",
+        "ambiguous",
+        "other",
+    }
+)
+JUDGE_WINDOW_MODES = frozenset({"merged", "fragmented"})
+DTMF_ACTION_SOURCES = frozenset({"realtime", "judge", "guard"})
+PRIVATE_DTMF_RE = re.compile(r"^[0-9*#]+$")
 
 
 class RegressionError(RuntimeError):
@@ -410,39 +425,69 @@ def check_dtmf_judge_shadow(
 ) -> CheckResult:
     """Summarize shadow/realtime alignment without printing cleartext digits."""
     title = "10. DTMF 判官 shadow 对齐"
-    public_decision_ids = {
-        value
-        for event in events
-        if event.get("type") == "dtmf_judge"
-        for value in [event.get("decision_id")]
-        if isinstance(value, str)
-    }
-    if not public_decision_ids:
+    public_decisions = [event for event in events if event.get("type") == "dtmf_judge"]
+    public_actions = [event for event in events if event.get("type") == "dtmf_action"]
+    judge_errors = sum(event.get("type") == "judge_error" for event in events)
+    if not public_decisions:
+        if judge_errors or public_actions or private_entries:
+            return CheckResult(
+                "dtmf_judge_shadow",
+                title,
+                "WARN",
+                f"decisions=0 errors={judge_errors} unjudged_action={len(public_actions)}",
+            )
         return CheckResult(
             "dtmf_judge_shadow", title, "PASS", "本通未产生 shadow 判定"
         )
 
-    public_action_ids = {
-        value
-        for event in events
-        if event.get("type") == "dtmf_action"
-        for value in [event.get("action_id")]
-        if isinstance(value, str)
-    }
-    decisions = [
-        entry
-        for entry in private_entries
-        if entry.get("kind") == "decision"
-        and entry.get("decision_id") in public_decision_ids
-    ]
-    actions = [
-        entry
-        for entry in private_entries
-        if entry.get("kind") == "action"
-        and entry.get("action_id") in public_action_ids
-    ]
-    missing_private = len(public_decision_ids) - len(decisions)
+    schema_errors = 0
+    missing_private = 0
+    private_decisions, duplicate_private_decisions = _index_private_entries(
+        private_entries, "decision", "decision_id"
+    )
+    private_actions, duplicate_private_actions = _index_private_entries(
+        private_entries, "action", "action_id"
+    )
+    schema_errors += duplicate_private_decisions + duplicate_private_actions
+
+    decisions: list[Event] = []
+    seen_decision_ids: set[str] = set()
+    for public in public_decisions:
+        decision_id = public.get("decision_id")
+        if not isinstance(decision_id, str) or decision_id in seen_decision_ids:
+            schema_errors += 1
+            continue
+        seen_decision_ids.add(decision_id)
+        private = private_decisions.get(decision_id)
+        if private is None:
+            missing_private += 1
+            continue
+        if not _valid_decision_pair(public, private):
+            schema_errors += 1
+            continue
+        decisions.append(private)
+
+    actions: list[Event] = []
+    seen_action_ids: set[str] = set()
+    for public in public_actions:
+        action_id = public.get("action_id")
+        if not isinstance(action_id, str) or action_id in seen_action_ids:
+            schema_errors += 1
+            continue
+        seen_action_ids.add(action_id)
+        private = private_actions.get(action_id)
+        if private is None:
+            missing_private += 1
+            continue
+        if not _valid_action_pair(public, private):
+            schema_errors += 1
+            continue
+        actions.append(private)
+
+    schema_errors += len(set(private_decisions) - seen_decision_ids)
+    schema_errors += len(set(private_actions) - seen_action_ids)
     press_decisions = [entry for entry in decisions if entry.get("action") == "press"]
+    nonpress_decisions = [entry for entry in decisions if entry.get("action") != "press"]
     exact = 0
     mismatch = 0
     no_action = 0
@@ -482,6 +527,35 @@ def check_dtmf_judge_shadow(
         else:
             mismatch += 1
 
+    unexpected_action = 0
+    unused_nonpress = list(nonpress_decisions)
+    for action in actions:
+        action_id = action.get("action_id")
+        if action_id not in unused_action_ids:
+            continue
+        action_ts = _number(action.get("ts"))
+        if action_ts is None:
+            continue
+        candidates = [
+            decision
+            for decision in unused_nonpress
+            if (decision_ts := _number(decision.get("ts"))) is not None
+            and abs(action_ts - decision_ts) <= 5.0
+        ]
+        if not candidates:
+            continue
+        nearest = min(
+            candidates,
+            key=lambda decision: abs(
+                action_ts - (_number(decision.get("ts")) or 0.0)
+            ),
+        )
+        unused_nonpress.remove(nearest)
+        if isinstance(action_id, str):
+            unused_action_ids.discard(action_id)
+        unexpected_action += 1
+    unjudged_action = len(unused_action_ids)
+
     modes: dict[str, int] = {}
     for decision in decisions:
         mode = decision.get("window_mode")
@@ -490,13 +564,113 @@ def check_dtmf_judge_shadow(
     mode_detail = ",".join(f"{key}={value}" for key, value in sorted(modes.items()))
     detail = (
         f"decisions={len(decisions)} press={len(press_decisions)} exact={exact} "
-        f"mismatch={mismatch} no_action={no_action} missing_private={missing_private}; "
+        f"mismatch={mismatch} no_action={no_action} "
+        f"unexpected_action={unexpected_action} unjudged_action={unjudged_action} "
+        f"missing_private={missing_private} schema_errors={schema_errors} "
+        f"errors={judge_errors}; "
         f"window_mode[{mode_detail or 'none'}]"
     )
     status: Status = (
-        "WARN" if mismatch or no_action or missing_private else "PASS"
+        "WARN"
+        if (
+            mismatch
+            or no_action
+            or unexpected_action
+            or unjudged_action
+            or missing_private
+            or schema_errors
+            or judge_errors
+        )
+        else "PASS"
     )
     return CheckResult("dtmf_judge_shadow", title, status, detail)
+
+
+def _index_private_entries(
+    entries: Sequence[Event], kind: str, id_field: str
+) -> tuple[dict[str, Event], int]:
+    indexed: dict[str, Event] = {}
+    duplicates = 0
+    for entry in entries:
+        if entry.get("kind") != kind:
+            continue
+        entry_id = entry.get(id_field)
+        if not isinstance(entry_id, str) or entry_id in indexed:
+            duplicates += 1
+            continue
+        indexed[entry_id] = entry
+    return indexed, duplicates
+
+
+def _valid_decision_pair(public: Event, private: Event) -> bool:
+    action = public.get("action")
+    confidence = _number(public.get("confidence"))
+    latency = _number(public.get("latency_ms"))
+    digits = private.get("digits")
+    digits_len = public.get("digits_len")
+    if (
+        not isinstance(action, str)
+        or action not in JUDGE_ACTIONS
+        or isinstance(public.get("confidence"), bool)
+        or confidence is None
+        or not 0.0 <= confidence <= 1.0
+        or not isinstance(public.get("reason_code"), str)
+        or public.get("reason_code") not in JUDGE_REASON_CODES
+        or latency is None
+        or latency < 0
+        or not isinstance(public.get("window_mode"), str)
+        or public.get("window_mode") not in JUDGE_WINDOW_MODES
+        or isinstance(digits_len, bool)
+        or not isinstance(digits_len, int)
+        or not isinstance(public.get("decision_id"), str)
+        or _number(public.get("ts")) is None
+    ):
+        return False
+    if action == "press":
+        if (
+            not isinstance(digits, str)
+            or re.fullmatch(r"[0-9*#]{1,4}", digits) is None
+            or digits_len != len(digits)
+        ):
+            return False
+    elif digits is not None or digits_len != 0:
+        return False
+    private_confidence = _number(private.get("confidence"))
+    private_latency = _number(private.get("latency_ms"))
+    reason = private.get("reason")
+    return bool(
+        private.get("decision_id") == public.get("decision_id")
+        and private.get("action") == action
+        and private_confidence == confidence
+        and private.get("reason_code") == public.get("reason_code")
+        and isinstance(reason, str)
+        and len(reason) <= 50
+        and private_latency == latency
+        and private.get("window_mode") == public.get("window_mode")
+        and _number(private.get("ts")) is not None
+    )
+
+
+def _valid_action_pair(public: Event, private: Event) -> bool:
+    source = public.get("source")
+    digits_len = public.get("digits_len")
+    digits = private.get("digits")
+    return bool(
+        isinstance(public.get("action_id"), str)
+        and isinstance(source, str)
+        and source in DTMF_ACTION_SOURCES
+        and isinstance(digits_len, int)
+        and not isinstance(digits_len, bool)
+        and digits_len > 0
+        and _number(public.get("ts")) is not None
+        and private.get("action_id") == public.get("action_id")
+        and private.get("source") == source
+        and isinstance(digits, str)
+        and PRIVATE_DTMF_RE.fullmatch(digits) is not None
+        and private.get("digits_len") == digits_len == len(digits)
+        and _number(private.get("ts")) is not None
+        and _number(private.get("t_ms")) is not None
+    )
 
 
 def load_events(call_dir: Path) -> list[dict[str, object]]:
@@ -844,7 +1018,8 @@ def _number(value: object) -> float | None:
     if isinstance(value, bool):
         return None
     if isinstance(value, int | float):
-        return float(value)
+        number = float(value)
+        return number if math.isfinite(number) else None
     return None
 
 

--- a/src/agentcall/call_agent.py
+++ b/src/agentcall/call_agent.py
@@ -159,7 +159,7 @@ class CallSession:
         self._next_dtmf_followup_id = 0
         self._dtmf_dispatch_context = threading.local()
         self._active_tools: ToolRegistry | None = None
-        self._dtmf_ledger = DtmfActionLedger()
+        self._dtmf_ledger: DtmfActionLedger | None = None
         self._dtmf_judge: DtmfJudge | None = None
         self._dtmf_judge_started_at = 0.0
 
@@ -199,7 +199,6 @@ class CallSession:
         self._cancel_spoken_dtmf_followups(clear_recent=True)
         self._stop_dtmf_judge(join_timeout=0.0)
         self._dtmf_judge_started_at = 0.0
-        self._dtmf_ledger.clear()
         # 世代号推进与置活必须同锁原子完成：与 _deferred_hangup 的
         # 「校验世代号 → stop()」互斥，保证旧回调要么在新会话置活前跑完
         # （只影响已结束的旧会话），要么校验失败直接放弃。
@@ -700,12 +699,13 @@ class CallSession:
         window_mode: WindowMode = (
             "merged" if config.get_bool("MANUAL_RESPONSE_CONTROL") else "fragmented"
         )
+        ledger = DtmfActionLedger()
         judge: DtmfJudge | None = None
         try:
             judge = DtmfJudge(
                 record=record,
                 task_goal=task_goal,
-                ledger=self._dtmf_ledger,
+                ledger=ledger,
                 model=model,
                 window_mode=window_mode,
             )
@@ -726,12 +726,17 @@ class CallSession:
                 window_mode=window_mode,
             )
             return
-        self._dtmf_judge_started_at = session_t0
-        self._dtmf_judge = judge
+        with self._dtmf_lock:
+            self._dtmf_judge_started_at = session_t0
+            self._dtmf_ledger = ledger
+            self._dtmf_judge = judge
 
     def _stop_dtmf_judge(self, *, join_timeout: float = 0.2) -> None:
-        judge = self._dtmf_judge
-        self._dtmf_judge = None
+        with self._dtmf_lock:
+            judge = self._dtmf_judge
+            self._dtmf_judge = None
+            self._dtmf_ledger = None
+            self._dtmf_judge_started_at = 0.0
         if judge is not None:
             try:
                 judge.stop(join_timeout=join_timeout)
@@ -1199,13 +1204,17 @@ class CallSession:
         }.get(source)
         if public_source is None:
             return
+        ledger = self._dtmf_ledger
+        judge = self._dtmf_judge
+        if ledger is None or judge is None:
+            return
         relative_time = (
             max(0.0, time.monotonic() - self._dtmf_judge_started_at)
             if self._dtmf_judge_started_at > 0
             else 0.0
         )
         try:
-            entry = self._dtmf_ledger.record(
+            entry = ledger.record(
                 digits,
                 public_source,  # type: ignore[arg-type]
                 timestamp=relative_time,
@@ -1218,9 +1227,7 @@ class CallSession:
         record = self._record
         if record is not None:
             record.log_event("dtmf_action", **entry.public_fields())
-        judge = self._dtmf_judge
-        if judge is not None:
-            judge.record_action(entry)
+        judge.record_action(entry)
 
     def _resolve_dtmf_mode(self) -> str:
         configured = config.get_str("DTMF_MODE").strip().lower()

--- a/src/agentcall/call_agent.py
+++ b/src/agentcall/call_agent.py
@@ -30,6 +30,7 @@ from .contacts import is_reply_target_allowed
 from .dial_queue import DialQueue, whitelist_from_env
 from .dtmf import dtmf_tone
 from .dtmf_followup import extract_spoken_dtmf
+from .dtmf_judge import DtmfActionLedger, DtmfJudge, WindowMode
 from .events import EventHub
 from .modem import Eg25Modem
 from .monitor_playback import MonitorPlayback
@@ -158,6 +159,9 @@ class CallSession:
         self._next_dtmf_followup_id = 0
         self._dtmf_dispatch_context = threading.local()
         self._active_tools: ToolRegistry | None = None
+        self._dtmf_ledger = DtmfActionLedger()
+        self._dtmf_judge: DtmfJudge | None = None
+        self._dtmf_judge_started_at = 0.0
 
     def _publish(self, event: dict) -> None:
         if self.hub:
@@ -193,6 +197,9 @@ class CallSession:
         self._prompt_gen_opening_mode = "say"
         self._prompt_gen_dtmf_spoken_followup = False
         self._cancel_spoken_dtmf_followups(clear_recent=True)
+        self._stop_dtmf_judge(join_timeout=0.0)
+        self._dtmf_judge_started_at = 0.0
+        self._dtmf_ledger.clear()
         # 世代号推进与置活必须同锁原子完成：与 _deferred_hangup 的
         # 「校验世代号 → stop()」互斥，保证旧回调要么在新会话置活前跑完
         # （只影响已结束的旧会话），要么校验失败直接放弃。
@@ -207,6 +214,7 @@ class CallSession:
         with self._dtmf_lock:
             self._active = False
             self._cancel_spoken_dtmf_followups_locked()
+        self._stop_dtmf_judge()
         if self._loop and self._loop.is_running():
             asyncio.run_coroutine_threadsafe(self._shutdown(), self._loop)
 
@@ -222,6 +230,7 @@ class CallSession:
                 self._active = False
                 self._cancel_spoken_dtmf_followups_locked()
                 self._active_tools = None
+            self._stop_dtmf_judge()
             # 会话收尾统一取消未触发的延迟挂断，不让它跨到下一通。
             self._cancel_hangup_timer()
             self._loop.close()
@@ -323,6 +332,7 @@ class CallSession:
                 tx_gain=self.tx_gain,
             )
             agent = create_agent(self.provider)
+            self._start_dtmf_judge(record, session_t0=session_t0)
             agent.set_session_instructions(self._build_agent_instructions(direction))
             agent.set_transcript_handler(
                 self._make_transcript_handler(record, transcripts, agent)
@@ -365,6 +375,8 @@ class CallSession:
             status = "failed"
             raise
         finally:
+            # 先作废判官世代再 finish record，避免迟到结果在 meta 落盘后追加事件。
+            self._stop_dtmf_judge()
             mark("ended", status=status)
             self._finalize_record(record, status, transcripts, direction, number)
 
@@ -419,6 +431,16 @@ class CallSession:
             )
             if role == "agent":
                 self._schedule_spoken_dtmf_followup(agent, text)
+            elif role == "user":
+                judge = self._dtmf_judge
+                if judge is not None:
+                    judge.submit_remote_transcript(
+                        text,
+                        t_ms=max(
+                            0.0,
+                            (time.monotonic() - self._dtmf_judge_started_at) * 1000,
+                        ),
+                    )
 
         return on_transcript
 
@@ -656,6 +678,67 @@ class CallSession:
             send_dtmf=self._send_dtmf_from_tool,
         )
         return tools.register()
+
+    def _start_dtmf_judge(
+        self, record: CallRecord | None, *, session_t0: float
+    ) -> None:
+        """Start the per-call shadow worker only when explicitly enabled."""
+        self._stop_dtmf_judge(join_timeout=0.0)
+        if record is None or config.get_str("DTMF_JUDGE_MODE").strip() != "shadow":
+            return
+        model = (
+            config.get_str("DTMF_JUDGE_MODEL").strip()
+            or config.get_str("PROMPT_GEN_MODEL").strip()
+            or "qwen-plus"
+        )
+        lang = agent_language()
+        task_goal = (
+            self._outbound_task(lang)
+            if self._outbound_number
+            else ("处理本次来电" if lang == "zh" else "handle this inbound call")
+        )
+        window_mode: WindowMode = (
+            "merged" if config.get_bool("MANUAL_RESPONSE_CONTROL") else "fragmented"
+        )
+        judge: DtmfJudge | None = None
+        try:
+            judge = DtmfJudge(
+                record=record,
+                task_goal=task_goal,
+                ledger=self._dtmf_ledger,
+                model=model,
+                window_mode=window_mode,
+            )
+            judge.start()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "DTMF 判官启动失败: error_type=%s", type(exc).__name__
+            )
+            if judge is not None:
+                try:
+                    judge.stop(join_timeout=0.0)
+                except Exception:  # noqa: BLE001
+                    pass
+            record.log_event(
+                "judge_error",
+                code="startup_error",
+                latency_ms=0.0,
+                window_mode=window_mode,
+            )
+            return
+        self._dtmf_judge_started_at = session_t0
+        self._dtmf_judge = judge
+
+    def _stop_dtmf_judge(self, *, join_timeout: float = 0.2) -> None:
+        judge = self._dtmf_judge
+        self._dtmf_judge = None
+        if judge is not None:
+            try:
+                judge.stop(join_timeout=join_timeout)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "DTMF 判官停止失败: error_type=%s", type(exc).__name__
+                )
 
     def _sms_target_allowed(self, number: str) -> bool:
         """发短信目标限制:只允许回复已联系过的号码或当前通话对端。
@@ -1103,9 +1186,41 @@ class CallSession:
                 sent = sent or ok
             if sent:
                 self._recent_dtmf_sent[digits] = (time.monotonic(), source)
+                self._record_dtmf_action(digits, source)
                 if source != "spoken_followup":
                     self._cancel_pending_dtmf_locked(digits)
             return ok, mode
+
+    def _record_dtmf_action(self, digits: str, source: str) -> None:
+        public_source = {
+            "agent_tool": "realtime",
+            "spoken_followup": "guard",
+            "judge": "judge",
+        }.get(source)
+        if public_source is None:
+            return
+        relative_time = (
+            max(0.0, time.monotonic() - self._dtmf_judge_started_at)
+            if self._dtmf_judge_started_at > 0
+            else 0.0
+        )
+        try:
+            entry = self._dtmf_ledger.record(
+                digits,
+                public_source,  # type: ignore[arg-type]
+                timestamp=relative_time,
+            )
+        except ValueError as exc:
+            logger.warning(
+                "DTMF action ledger 拒绝记录: error_type=%s", type(exc).__name__
+            )
+            return
+        record = self._record
+        if record is not None:
+            record.log_event("dtmf_action", **entry.public_fields())
+        judge = self._dtmf_judge
+        if judge is not None:
+            judge.record_action(entry)
 
     def _resolve_dtmf_mode(self) -> str:
         configured = config.get_str("DTMF_MODE").strip().lower()

--- a/src/agentcall/config.py
+++ b/src/agentcall/config.py
@@ -211,6 +211,10 @@ CONFIG_SPECS: tuple[ConfigSpec, ...] = (
     ConfigSpec("MANUAL_RESPONSE_CONTROL", "手动应答控制", "bool", "false"),
     ConfigSpec("MANUAL_RESPONSE_SILENCE_MS", "手动应答静默窗口（毫秒）", "int", "1000"),
     ConfigSpec("MANUAL_RESPONSE_MAX_WAIT_MS", "手动应答最长等待（毫秒）", "int", "8000"),
+    # 文本判官本批仅实现旁观模式；enforce 不进 choices，配置写回会在边界拒绝。
+    ConfigSpec("DTMF_JUDGE_MODE", "DTMF 文本判官", "select", "off",
+               choices=("off", "shadow")),
+    ConfigSpec("DTMF_JUDGE_MODEL", "DTMF 判官文本模型", "str", ""),
     # ---- 模组 ----
     # 默认值按当前平台在模块加载时定死（Windows 为 auto 哨兵，连接时扫描）。
     ConfigSpec("MODEM_PORT", "模组 AT 串口", "str", platforms.default_modem_port(),
@@ -436,6 +440,12 @@ def validate_provider_credentials(provider: str) -> list[str]:
     for key in required:
         if not os.environ.get(key, "").strip():
             errors.append(f"缺少环境变量 {key}（{provider} 必需）")
+    if (
+        get_str("DTMF_JUDGE_MODE") == "shadow"
+        and not os.environ.get("DASHSCOPE_API_KEY", "").strip()
+        and "DASHSCOPE_API_KEY" not in required
+    ):
+        errors.append("缺少环境变量 DASHSCOPE_API_KEY（DTMF 文本判官 shadow 必需）")
     return errors
 
 

--- a/src/agentcall/dtmf_judge.py
+++ b/src/agentcall/dtmf_judge.py
@@ -21,7 +21,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Literal, Protocol, cast
 
-from .prompt_gen import _call_qwen
+import dashscope
+
+from .summarizer import _extract_text
 
 logger = logging.getLogger(__name__)
 
@@ -156,7 +158,9 @@ class DtmfActionLedger:
 def parse_judge_decision(text: str) -> JudgeDecision:
     """Parse one strict JSON decision; never coerce unsafe model output."""
     try:
-        payload = json.loads(text)
+        payload = json.loads(text, object_pairs_hook=_unique_object)
+    except JudgeValidationError:
+        raise
     except (json.JSONDecodeError, TypeError):
         raise JudgeValidationError("invalid_json") from None
     if not isinstance(payload, dict):
@@ -266,6 +270,7 @@ class DtmfJudge:
         self._thread: threading.Thread | None = None
         self._model_thread: threading.Thread | None = None
         self._private_lock = threading.Lock()
+        self._private_lines: list[str] = []
 
     def start(self) -> None:
         with self._condition:
@@ -304,9 +309,10 @@ class DtmfJudge:
             self._condition.notify_all()
         if thread is not None and thread is not threading.current_thread():
             thread.join(timeout=max(0.0, join_timeout))
+        self._flush_private()
 
     def record_action(self, entry: DtmfAction) -> None:
-        """Append cleartext action data only to the private per-call analysis file."""
+        """Buffer cleartext action data for the private per-call analysis file."""
         with self._condition:
             if not self._running:
                 return
@@ -319,7 +325,7 @@ class DtmfJudge:
                 "digits": entry.digits,
                 "digits_len": len(entry.digits),
             }
-            self._append_private(private)
+            self._buffer_private_locked(private)
 
     def _run(self, generation: int) -> None:
         while True:
@@ -344,19 +350,20 @@ class DtmfJudge:
             text, error_code = self._invoke_model(messages)
             latency_ms = round((time.monotonic() - started) * 1000, 1)
 
-            if not self._is_current(generation):
-                return
             if error_code is not None:
-                self._log_error(_sanitize_error_code(error_code), latency_ms)
+                if not self._commit_error(
+                    generation, _sanitize_error_code(error_code), latency_ms
+                ):
+                    return
                 continue
             try:
                 decision = parse_judge_decision(text or "")
             except JudgeValidationError as exc:
-                self._log_error(exc.code, latency_ms)
+                if not self._commit_error(generation, exc.code, latency_ms):
+                    return
                 continue
-            if not self._is_current(generation):
+            if not self._commit_decision(generation, decision, latency_ms):
                 return
-            self._log_decision(decision, latency_ms)
 
     def _invoke_model(
         self, messages: list[dict[str, str]]
@@ -401,47 +408,69 @@ class DtmfJudge:
             return None, "model_error"
         return result
 
-    def _is_current(self, generation: int) -> bool:
+    def _commit_error(
+        self, generation: int, code: str, latency_ms: float
+    ) -> bool:
+        """Atomically reject stale results or append one public in-memory event."""
         with self._condition:
-            return self._running and generation == self._generation
+            if not self._running or generation != self._generation:
+                return False
+            self._record.log_event(
+                "judge_error",
+                code=code,
+                latency_ms=latency_ms,
+                window_mode=self._window_mode,
+            )
+            return True
 
-    def _log_error(self, code: str, latency_ms: float) -> None:
-        self._record.log_event(
-            "judge_error",
-            code=code,
-            latency_ms=latency_ms,
-            window_mode=self._window_mode,
-        )
+    def _commit_decision(
+        self,
+        generation: int,
+        decision: JudgeDecision,
+        latency_ms: float,
+    ) -> bool:
+        """Atomically commit correlated public/private in-memory records."""
+        with self._condition:
+            if not self._running or generation != self._generation:
+                return False
+            decision_id = self._id_factory()
+            digits_len = len(decision.digits or "")
+            timestamp = time.time()
+            self._record.log_event(
+                "dtmf_judge",
+                action=decision.action,
+                confidence=decision.confidence,
+                reason_code=decision.reason_code,
+                latency_ms=latency_ms,
+                window_mode=self._window_mode,
+                digits_len=digits_len,
+                decision_id=decision_id,
+            )
+            self._buffer_private_locked(
+                {
+                    "kind": "decision",
+                    "decision_id": decision_id,
+                    "ts": timestamp,
+                    "action": decision.action,
+                    "digits": decision.digits,
+                    "confidence": decision.confidence,
+                    "reason_code": decision.reason_code,
+                    "reason": decision.reason,
+                    "latency_ms": latency_ms,
+                    "window_mode": self._window_mode,
+                }
+            )
+            return True
 
-    def _log_decision(self, decision: JudgeDecision, latency_ms: float) -> None:
-        decision_id = self._id_factory()
-        digits_len = len(decision.digits or "")
-        self._record.log_event(
-            "dtmf_judge",
-            action=decision.action,
-            confidence=decision.confidence,
-            reason_code=decision.reason_code,
-            latency_ms=latency_ms,
-            window_mode=self._window_mode,
-            digits_len=digits_len,
-            decision_id=decision_id,
-        )
-        private = {
-            "kind": "decision",
-            "decision_id": decision_id,
-            "ts": time.time(),
-            "action": decision.action,
-            "digits": decision.digits,
-            "confidence": decision.confidence,
-            "reason_code": decision.reason_code,
-            "reason": decision.reason,
-            "latency_ms": latency_ms,
-            "window_mode": self._window_mode,
-        }
-        self._append_private(private)
+    def _buffer_private_locked(self, item: dict[str, object]) -> None:
+        self._private_lines.append(json.dumps(item, ensure_ascii=False) + "\n")
 
-    def _append_private(self, item: dict[str, object]) -> None:
-        line = json.dumps(item, ensure_ascii=False) + "\n"
+    def _flush_private(self) -> None:
+        with self._condition:
+            lines = self._private_lines
+            self._private_lines = []
+        if not lines:
+            return
         path = self._record.path / "judge_shadow.jsonl"
         try:
             with self._private_lock:
@@ -451,7 +480,7 @@ class DtmfJudge:
                     encoding="utf-8",
                     opener=lambda file_path, flags: os.open(file_path, flags, 0o600),
                 ) as file:
-                    file.write(line)
+                    file.writelines(lines)
         except OSError as exc:
             logger.warning(
                 "DTMF 判官隐私分析记录写入失败: error_type=%s",
@@ -460,14 +489,22 @@ class DtmfJudge:
 
 
 def _default_model_call(
-    messages: list[dict[str, str]], model: str, timeout: float
+    messages: list[dict[str, str]], model: str, _timeout: float
 ) -> tuple[str | None, str | None]:
-    text, error = _call_qwen(messages, model, timeout)
-    if error is None:
-        return text, None
-    if "超时" in error or "timeout" in error.lower():
-        return None, "timeout"
-    return None, "model_error"
+    """Make one synchronous SDK request; ``_invoke_model`` owns its timeout."""
+    if not os.environ.get("DASHSCOPE_API_KEY", "").strip():
+        return None, "model_error"
+    response = dashscope.Generation.call(
+        model=model,
+        messages=messages,
+        result_format="message",
+        api_key=os.environ.get("DASHSCOPE_API_KEY"),
+    )
+    status = getattr(response, "status_code", None)
+    if status is not None and status != 200:
+        return None, "model_error"
+    text = _extract_text(response)
+    return (text, None) if text else (None, "model_error")
 
 
 def _sanitize_error_code(code: str) -> str:
@@ -482,9 +519,19 @@ def _sanitize_error_code(code: str) -> str:
         "invalid_confidence",
         "invalid_reason_code",
         "invalid_reason",
+        "duplicate_fields",
     }
     return code if code in allowed else "model_error"
 
 
 def _opaque_id() -> str:
     return uuid.uuid4().hex
+
+
+def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise JudgeValidationError("duplicate_fields")
+        result[key] = value
+    return result

--- a/src/agentcall/dtmf_judge.py
+++ b/src/agentcall/dtmf_judge.py
@@ -1,0 +1,490 @@
+"""Shadow DTMF decision judge driven by remote-party transcripts.
+
+The judge never sends DTMF in shadow mode. It runs on one daemon worker,
+coalesces transcript fragments, and keeps cleartext decisions only beside the
+private per-call recording artifacts. Public events deliberately contain no
+DTMF value or value-derived fingerprint.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+import re
+import threading
+import time
+import uuid
+from collections import deque
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Literal, Protocol, cast
+
+from .prompt_gen import _call_qwen
+
+logger = logging.getLogger(__name__)
+
+JudgeAction = Literal["press", "wait", "speak", "human", "unknown"]
+JudgeReasonCode = Literal[
+    "menu_matched",
+    "menu_incomplete",
+    "queue_hold",
+    "human_detected",
+    "ambiguous",
+    "other",
+]
+DtmfActionSource = Literal["realtime", "judge", "guard"]
+WindowMode = Literal["merged", "fragmented"]
+
+_ACTIONS = frozenset({"press", "wait", "speak", "human", "unknown"})
+_REASON_CODES = frozenset(
+    {
+        "menu_matched",
+        "menu_incomplete",
+        "queue_hold",
+        "human_detected",
+        "ambiguous",
+        "other",
+    }
+)
+_ACTION_SOURCES = frozenset({"realtime", "judge", "guard"})
+_DIGITS_RE = re.compile(r"^[0-9*#]{1,4}$")
+_EXPECTED_FIELDS = frozenset(
+    {"action", "digits", "confidence", "reason_code", "reason"}
+)
+_MAX_TRANSCRIPTS = 8
+_MAX_RECENT_ACTIONS = 3
+
+_SYSTEM_PROMPT = (
+    "你是电话按键决策器。只输出一个严格合法的 JSON 对象，不要 Markdown 或额外文字。"
+    "根据最近的对方话语流、我方任务目标和已按键历史，判断当前正确动作。"
+    "只在对方明确给出按键选项，且某选项显然通向任务目标或转人工时才 press；"
+    "播报未完、没有菜单或仍在排队时 wait；应由语音助手回答时 speak；"
+    "明确接到人工时 human；无法可靠判断时 unknown。不得使用预置关键词映射。"
+    '输出字段固定为 action、confidence、reason_code、reason；仅 action="press" 时'
+    "增加 digits（1-4 位，仅 0-9、*、#），其他 action 禁止输出 digits。"
+    "confidence 必须是 0 到 1 的有限数字，reason 不超过 50 字。"
+)
+
+
+class JudgeRecord(Protocol):
+    path: Path
+
+    def log_event(self, type: str, **fields: Any) -> None: ...  # noqa: A002
+
+
+ModelCall = Callable[
+    [list[dict[str, str]], str, float], tuple[str | None, str | None]
+]
+IdFactory = Callable[[], str]
+
+
+class JudgeValidationError(ValueError):
+    """A model response failed the strict judge contract."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class JudgeDecision:
+    action: JudgeAction
+    digits: str | None
+    confidence: float
+    reason_code: JudgeReasonCode
+    reason: str
+
+
+@dataclass(frozen=True)
+class DtmfAction:
+    action_id: str
+    source: DtmfActionSource
+    digits: str
+    timestamp: float
+
+    def public_fields(self) -> dict[str, str | int]:
+        return {
+            "action_id": self.action_id,
+            "source": self.source,
+            "digits_len": len(self.digits),
+        }
+
+
+class DtmfActionLedger:
+    """Thread-safe action history; cleartext digits remain memory-only."""
+
+    def __init__(self, *, id_factory: IdFactory | None = None) -> None:
+        self._id_factory = id_factory or _opaque_id
+        self._entries: deque[DtmfAction] = deque(maxlen=32)
+        self._lock = threading.Lock()
+
+    def record(
+        self,
+        digits: str,
+        source: DtmfActionSource,
+        *,
+        timestamp: float | None = None,
+    ) -> DtmfAction:
+        if source not in _ACTION_SOURCES:
+            raise ValueError(f"unsupported DTMF action source: {source}")
+        normalized = digits.strip()
+        if not normalized or not re.fullmatch(r"[0-9*#]+", normalized):
+            raise ValueError("DTMF action digits must contain only 0-9, * or #")
+        entry = DtmfAction(
+            action_id=self._id_factory(),
+            source=source,
+            digits=normalized,
+            timestamp=time.monotonic() if timestamp is None else timestamp,
+        )
+        with self._lock:
+            self._entries.append(entry)
+        return entry
+
+    def recent(self, limit: int = _MAX_RECENT_ACTIONS) -> tuple[DtmfAction, ...]:
+        if limit <= 0:
+            return ()
+        with self._lock:
+            return tuple(self._entries)[-limit:]
+
+    def clear(self) -> None:
+        with self._lock:
+            self._entries.clear()
+
+
+def parse_judge_decision(text: str) -> JudgeDecision:
+    """Parse one strict JSON decision; never coerce unsafe model output."""
+    try:
+        payload = json.loads(text)
+    except (json.JSONDecodeError, TypeError):
+        raise JudgeValidationError("invalid_json") from None
+    if not isinstance(payload, dict):
+        raise JudgeValidationError("invalid_schema")
+    if set(payload) - _EXPECTED_FIELDS:
+        raise JudgeValidationError("invalid_schema")
+
+    action = payload.get("action")
+    if not isinstance(action, str) or action not in _ACTIONS:
+        raise JudgeValidationError("invalid_action")
+
+    has_digits = "digits" in payload
+    digits = payload.get("digits")
+    if action == "press":
+        if not isinstance(digits, str) or _DIGITS_RE.fullmatch(digits) is None:
+            raise JudgeValidationError("invalid_digits")
+    elif has_digits:
+        raise JudgeValidationError("unexpected_digits")
+    else:
+        digits = None
+
+    confidence = payload.get("confidence")
+    if (
+        isinstance(confidence, bool)
+        or not isinstance(confidence, (int, float))
+        or not math.isfinite(float(confidence))
+        or not 0.0 <= float(confidence) <= 1.0
+    ):
+        raise JudgeValidationError("invalid_confidence")
+
+    reason_code = payload.get("reason_code")
+    if not isinstance(reason_code, str) or reason_code not in _REASON_CODES:
+        raise JudgeValidationError("invalid_reason_code")
+    reason = payload.get("reason")
+    if not isinstance(reason, str) or len(reason) > 50:
+        raise JudgeValidationError("invalid_reason")
+
+    return JudgeDecision(
+        action=cast(JudgeAction, action),
+        digits=digits,
+        confidence=float(confidence),
+        reason_code=cast(JudgeReasonCode, reason_code),
+        reason=reason,
+    )
+
+
+def build_judge_messages(
+    transcripts: list[tuple[float, str]],
+    recent_actions: tuple[DtmfAction, ...],
+    task_goal: str,
+) -> list[dict[str, str]]:
+    """Build the bounded text-model input without enumerating IVR phrases."""
+    transcript_window = transcripts[-_MAX_TRANSCRIPTS:]
+    action_window = recent_actions[-_MAX_RECENT_ACTIONS:]
+    payload = {
+        "task_goal": (task_goal or "").strip(),
+        "remote_transcripts": [
+            {"t_ms": round(t_ms, 1), "text": text}
+            for t_ms, text in transcript_window
+        ],
+        "recent_dtmf": [
+            {
+                "t_ms": round(entry.timestamp * 1000, 1),
+                "source": entry.source,
+                "digits": entry.digits,
+            }
+            for entry in action_window
+        ],
+    }
+    return [
+        {"role": "system", "content": _SYSTEM_PROMPT},
+        {"role": "user", "content": json.dumps(payload, ensure_ascii=False)},
+    ]
+
+
+class DtmfJudge:
+    """Single-worker, transcript-batching shadow judge for one call."""
+
+    def __init__(
+        self,
+        *,
+        record: JudgeRecord,
+        task_goal: str,
+        ledger: DtmfActionLedger,
+        model: str,
+        window_mode: WindowMode,
+        model_call: ModelCall | None = None,
+        throttle_seconds: float = 1.5,
+        timeout_seconds: float = 3.0,
+        id_factory: IdFactory | None = None,
+    ) -> None:
+        self._record = record
+        self._task_goal = task_goal
+        self._ledger = ledger
+        self._model = model
+        self._window_mode = window_mode
+        self._model_call = model_call or _default_model_call
+        self._throttle_seconds = max(0.0, throttle_seconds)
+        self._timeout_seconds = max(0.01, timeout_seconds)
+        self._id_factory = id_factory or _opaque_id
+        self._condition = threading.Condition()
+        self._segments: deque[tuple[float, str]] = deque(maxlen=_MAX_TRANSCRIPTS)
+        self._pending = False
+        self._deadline = 0.0
+        self._running = False
+        self._generation = 0
+        self._thread: threading.Thread | None = None
+        self._model_thread: threading.Thread | None = None
+        self._private_lock = threading.Lock()
+
+    def start(self) -> None:
+        with self._condition:
+            if self._running:
+                return
+            self._running = True
+            self._generation += 1
+            generation = self._generation
+            self._thread = threading.Thread(
+                target=self._run,
+                args=(generation,),
+                name="dtmf-judge-shadow",
+                daemon=True,
+            )
+            self._thread.start()
+
+    def submit_remote_transcript(self, text: str, *, t_ms: float) -> None:
+        normalized = (text or "").strip()
+        if not normalized:
+            return
+        with self._condition:
+            if not self._running:
+                return
+            self._segments.append((max(0.0, float(t_ms)), normalized))
+            if not self._pending:
+                self._pending = True
+                self._deadline = time.monotonic() + self._throttle_seconds
+            self._condition.notify()
+
+    def stop(self, *, join_timeout: float = 0.2) -> None:
+        with self._condition:
+            self._running = False
+            self._generation += 1
+            self._pending = False
+            thread = self._thread
+            self._condition.notify_all()
+        if thread is not None and thread is not threading.current_thread():
+            thread.join(timeout=max(0.0, join_timeout))
+
+    def record_action(self, entry: DtmfAction) -> None:
+        """Append cleartext action data only to the private per-call analysis file."""
+        with self._condition:
+            if not self._running:
+                return
+            private = {
+                "kind": "action",
+                "action_id": entry.action_id,
+                "ts": time.time(),
+                "t_ms": round(entry.timestamp * 1000, 1),
+                "source": entry.source,
+                "digits": entry.digits,
+                "digits_len": len(entry.digits),
+            }
+            self._append_private(private)
+
+    def _run(self, generation: int) -> None:
+        while True:
+            with self._condition:
+                while self._running and not self._pending:
+                    self._condition.wait()
+                if not self._running or generation != self._generation:
+                    return
+                remaining = self._deadline - time.monotonic()
+                if remaining > 0:
+                    self._condition.wait(timeout=remaining)
+                    continue
+                transcripts = list(self._segments)
+                self._pending = False
+
+            started = time.monotonic()
+            messages = build_judge_messages(
+                transcripts,
+                self._ledger.recent(_MAX_RECENT_ACTIONS),
+                self._task_goal,
+            )
+            text, error_code = self._invoke_model(messages)
+            latency_ms = round((time.monotonic() - started) * 1000, 1)
+
+            if not self._is_current(generation):
+                return
+            if error_code is not None:
+                self._log_error(_sanitize_error_code(error_code), latency_ms)
+                continue
+            try:
+                decision = parse_judge_decision(text or "")
+            except JudgeValidationError as exc:
+                self._log_error(exc.code, latency_ms)
+                continue
+            if not self._is_current(generation):
+                return
+            self._log_decision(decision, latency_ms)
+
+    def _invoke_model(
+        self, messages: list[dict[str, str]]
+    ) -> tuple[str | None, str | None]:
+        """Enforce the judge timeout even if an SDK call ignores its timeout hint."""
+        previous = self._model_thread
+        if previous is not None and previous.is_alive():
+            return None, "timeout"
+
+        box: dict[str, object] = {}
+
+        def call() -> None:
+            try:
+                box["result"] = self._model_call(
+                    messages, self._model, self._timeout_seconds
+                )
+            except Exception as exc:  # noqa: BLE001
+                box["error_type"] = type(exc).__name__
+
+        thread = threading.Thread(
+            target=call,
+            name="dtmf-judge-model-call",
+            daemon=True,
+        )
+        self._model_thread = thread
+        thread.start()
+        thread.join(self._timeout_seconds)
+        if thread.is_alive():
+            return None, "timeout"
+        self._model_thread = None
+        error_type = box.get("error_type")
+        if isinstance(error_type, str):
+            logger.warning("DTMF 判官调用异常: error_type=%s", error_type)
+            return None, "model_error"
+        result = box.get("result")
+        if (
+            not isinstance(result, tuple)
+            or len(result) != 2
+            or not (result[0] is None or isinstance(result[0], str))
+            or not (result[1] is None or isinstance(result[1], str))
+        ):
+            return None, "model_error"
+        return result
+
+    def _is_current(self, generation: int) -> bool:
+        with self._condition:
+            return self._running and generation == self._generation
+
+    def _log_error(self, code: str, latency_ms: float) -> None:
+        self._record.log_event(
+            "judge_error",
+            code=code,
+            latency_ms=latency_ms,
+            window_mode=self._window_mode,
+        )
+
+    def _log_decision(self, decision: JudgeDecision, latency_ms: float) -> None:
+        decision_id = self._id_factory()
+        digits_len = len(decision.digits or "")
+        self._record.log_event(
+            "dtmf_judge",
+            action=decision.action,
+            confidence=decision.confidence,
+            reason_code=decision.reason_code,
+            latency_ms=latency_ms,
+            window_mode=self._window_mode,
+            digits_len=digits_len,
+            decision_id=decision_id,
+        )
+        private = {
+            "kind": "decision",
+            "decision_id": decision_id,
+            "ts": time.time(),
+            "action": decision.action,
+            "digits": decision.digits,
+            "confidence": decision.confidence,
+            "reason_code": decision.reason_code,
+            "reason": decision.reason,
+            "latency_ms": latency_ms,
+            "window_mode": self._window_mode,
+        }
+        self._append_private(private)
+
+    def _append_private(self, item: dict[str, object]) -> None:
+        line = json.dumps(item, ensure_ascii=False) + "\n"
+        path = self._record.path / "judge_shadow.jsonl"
+        try:
+            with self._private_lock:
+                with open(
+                    path,
+                    "a",
+                    encoding="utf-8",
+                    opener=lambda file_path, flags: os.open(file_path, flags, 0o600),
+                ) as file:
+                    file.write(line)
+        except OSError as exc:
+            logger.warning(
+                "DTMF 判官隐私分析记录写入失败: error_type=%s",
+                type(exc).__name__,
+            )
+
+
+def _default_model_call(
+    messages: list[dict[str, str]], model: str, timeout: float
+) -> tuple[str | None, str | None]:
+    text, error = _call_qwen(messages, model, timeout)
+    if error is None:
+        return text, None
+    if "超时" in error or "timeout" in error.lower():
+        return None, "timeout"
+    return None, "model_error"
+
+
+def _sanitize_error_code(code: str) -> str:
+    allowed = {
+        "timeout",
+        "model_error",
+        "invalid_json",
+        "invalid_schema",
+        "invalid_action",
+        "invalid_digits",
+        "unexpected_digits",
+        "invalid_confidence",
+        "invalid_reason_code",
+        "invalid_reason",
+    }
+    return code if code in allowed else "model_error"
+
+
+def _opaque_id() -> str:
+    return uuid.uuid4().hex

--- a/src/agentcall/dtmf_judge.py
+++ b/src/agentcall/dtmf_judge.py
@@ -57,6 +57,8 @@ _EXPECTED_FIELDS = frozenset(
 )
 _MAX_TRANSCRIPTS = 8
 _MAX_RECENT_ACTIONS = 3
+_MODEL_SINGLE_FLIGHT_LOCK = threading.Lock()
+_MODEL_SINGLE_FLIGHT_THREAD: threading.Thread | None = None
 
 _SYSTEM_PROMPT = (
     "你是电话按键决策器。只输出一个严格合法的 JSON 对象，不要 Markdown 或额外文字。"
@@ -268,7 +270,6 @@ class DtmfJudge:
         self._running = False
         self._generation = 0
         self._thread: threading.Thread | None = None
-        self._model_thread: threading.Thread | None = None
         self._private_lock = threading.Lock()
         self._private_lines: list[str] = []
 
@@ -369,31 +370,41 @@ class DtmfJudge:
         self, messages: list[dict[str, str]]
     ) -> tuple[str | None, str | None]:
         """Enforce the judge timeout even if an SDK call ignores its timeout hint."""
-        previous = self._model_thread
-        if previous is not None and previous.is_alive():
-            return None, "timeout"
+        global _MODEL_SINGLE_FLIGHT_THREAD
 
         box: dict[str, object] = {}
 
         def call() -> None:
+            global _MODEL_SINGLE_FLIGHT_THREAD
             try:
                 box["result"] = self._model_call(
                     messages, self._model, self._timeout_seconds
                 )
             except Exception as exc:  # noqa: BLE001
                 box["error_type"] = type(exc).__name__
+            finally:
+                with _MODEL_SINGLE_FLIGHT_LOCK:
+                    if _MODEL_SINGLE_FLIGHT_THREAD is threading.current_thread():
+                        _MODEL_SINGLE_FLIGHT_THREAD = None
 
         thread = threading.Thread(
             target=call,
             name="dtmf-judge-model-call",
             daemon=True,
         )
-        self._model_thread = thread
-        thread.start()
+        with _MODEL_SINGLE_FLIGHT_LOCK:
+            previous = _MODEL_SINGLE_FLIGHT_THREAD
+            if previous is not None and previous.is_alive():
+                return None, "timeout"
+            _MODEL_SINGLE_FLIGHT_THREAD = thread
+            try:
+                thread.start()
+            except Exception:  # noqa: BLE001
+                _MODEL_SINGLE_FLIGHT_THREAD = None
+                return None, "model_error"
         thread.join(self._timeout_seconds)
         if thread.is_alive():
             return None, "timeout"
-        self._model_thread = None
         error_type = box.get("error_type")
         if isinstance(error_type, str):
             logger.warning("DTMF 判官调用异常: error_type=%s", error_type)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -106,6 +106,37 @@ def test_recording_registry_and_env_example_default_to_off():
     assert re.search(r"^RECORDING_ENABLED=false$", example, re.MULTILINE)
 
 
+def test_dtmf_judge_registry_defaults_off_and_rejects_enforce(tmp_path, monkeypatch):
+    _unset(monkeypatch, "DTMF_JUDGE_MODE", "DTMF_JUDGE_MODEL")
+    example = (Path(__file__).resolve().parents[2] / ".env.example").read_text(
+        encoding="utf-8"
+    )
+
+    mode_spec = get_spec("DTMF_JUDGE_MODE")
+    assert mode_spec.kind == "select"
+    assert mode_spec.default == "off"
+    assert mode_spec.choices == ("off", "shadow")
+    assert mode_spec.requires_restart is False
+    assert get_str("DTMF_JUDGE_MODEL") == ""
+    assert re.search(r"^DTMF_JUDGE_MODE=off$", example, re.MULTILINE)
+    assert re.search(r"^DTMF_JUDGE_MODEL=$", example, re.MULTILINE)
+
+    with pytest.raises(ValueError, match="off, shadow"):
+        update_env_file(
+            {"DTMF_JUDGE_MODE": "enforce"}, env_path=tmp_path / ".env"
+        )
+
+
+def test_shadow_judge_requires_dashscope_key_even_with_openai_agent(monkeypatch):
+    monkeypatch.setenv("DTMF_JUDGE_MODE", "shadow")
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
+    monkeypatch.delenv("DASHSCOPE_API_KEY", raising=False)
+
+    errors = validate_provider_credentials("openai")
+
+    assert any("DASHSCOPE_API_KEY" in error and "DTMF" in error for error in errors)
+
+
 @pytest.mark.parametrize(("raw", "expected"), [("true", True), ("false", False)])
 def test_recording_explicit_config_is_respected(monkeypatch, raw, expected):
     monkeypatch.setenv("RECORDING_ENABLED", raw)

--- a/tests/unit/test_dtmf_judge.py
+++ b/tests/unit/test_dtmf_judge.py
@@ -43,6 +43,15 @@ def wait_until(predicate, timeout: float = 2.0) -> None:
     raise AssertionError("condition was not met before timeout")
 
 
+def wait_for_model_threads() -> None:
+    wait_until(
+        lambda: not any(
+            thread.name == "dtmf-judge-model-call" and thread.is_alive()
+            for thread in threading.enumerate()
+        )
+    )
+
+
 def valid_response(*, digits: str = "1") -> str:
     return json.dumps(
         {
@@ -346,6 +355,7 @@ def test_model_call_exceeding_timeout_is_abandoned_without_blocking_worker(tmp_p
     wait_until(lambda: any(kind == "judge_error" for kind, _ in record.events))
     judge.stop()
     release.set()
+    wait_for_model_threads()
 
     error = next(fields for kind, fields in record.events if kind == "judge_error")
     assert error["code"] == "timeout"
@@ -397,6 +407,61 @@ def test_default_model_timeout_never_starts_a_second_live_sdk_request(
 
     judge.stop()
     release.set()
+    wait_for_model_threads()
+    assert calls == 1
+
+
+def test_default_model_single_flight_is_shared_across_call_instances(
+    tmp_path, monkeypatch
+):
+    entered = threading.Event()
+    release = threading.Event()
+    calls = 0
+
+    def blocked_sdk_call(**kwargs):
+        nonlocal calls
+        calls += 1
+        entered.set()
+        release.wait(timeout=10)
+        return None
+
+    monkeypatch.setattr(
+        dashscope.Generation, "call", staticmethod(blocked_sdk_call)
+    )
+    first = DtmfJudge(
+        record=SpyRecord(tmp_path / "first"),
+        task_goal="查询套餐余量",
+        ledger=DtmfActionLedger(),
+        model="qwen-plus",
+        window_mode="fragmented",
+        throttle_seconds=0.01,
+        timeout_seconds=0.03,
+    )
+    first.start()
+    first.submit_remote_transcript("第一通菜单", t_ms=10.0)
+    assert entered.wait(timeout=1)
+    time.sleep(0.05)
+    first.stop()
+
+    second_record = SpyRecord(tmp_path / "second")
+    second = DtmfJudge(
+        record=second_record,
+        task_goal="查询套餐余量",
+        ledger=DtmfActionLedger(),
+        model="qwen-plus",
+        window_mode="fragmented",
+        throttle_seconds=0.01,
+        timeout_seconds=0.03,
+    )
+    second.start()
+    second.submit_remote_transcript("第二通菜单", t_ms=10.0)
+    wait_until(
+        lambda: any(kind == "judge_error" for kind, _ in second_record.events)
+    )
+    second.stop()
+    release.set()
+    wait_for_model_threads()
+
     assert calls == 1
 
 
@@ -431,7 +496,7 @@ def test_blocked_judge_does_not_block_submit_or_stop_and_stale_result_is_dropped
     judge.stop(join_timeout=0.05)
     assert time.monotonic() - stopped_at < 0.2
     release.set()
-    time.sleep(0.05)
+    wait_for_model_threads()
 
     assert record.events == []
     assert not (record.path / "judge_shadow.jsonl").exists()

--- a/tests/unit/test_dtmf_judge.py
+++ b/tests/unit/test_dtmf_judge.py
@@ -10,6 +10,7 @@ import threading
 import time
 from pathlib import Path
 
+import dashscope
 import pytest
 
 from agentcall.dtmf_judge import (
@@ -124,6 +125,16 @@ def test_parse_judge_decision_accepts_strict_contract():
 )
 def test_parse_judge_decision_rejects_malformed_or_unsafe_payload(payload):
     with pytest.raises(JudgeValidationError):
+        parse_judge_decision(payload)
+
+
+def test_parse_judge_decision_rejects_duplicate_json_keys():
+    payload = (
+        '{"action":"wait","action":"press","digits":"1",'
+        '"confidence":0.9,"reason_code":"menu_matched","reason":"x"}'
+    )
+
+    with pytest.raises(JudgeValidationError, match="duplicate_fields"):
         parse_judge_decision(payload)
 
 
@@ -340,6 +351,55 @@ def test_model_call_exceeding_timeout_is_abandoned_without_blocking_worker(tmp_p
     assert error["code"] == "timeout"
 
 
+def test_default_model_timeout_never_starts_a_second_live_sdk_request(
+    tmp_path, monkeypatch
+):
+    record = SpyRecord(tmp_path / "recording")
+    entered = threading.Event()
+    release = threading.Event()
+    calls = 0
+
+    def blocked_sdk_call(**kwargs):
+        nonlocal calls
+        calls += 1
+        entered.set()
+        release.wait(timeout=10)
+        return None
+
+    monkeypatch.setattr(
+        dashscope.Generation, "call", staticmethod(blocked_sdk_call)
+    )
+    judge = DtmfJudge(
+        record=record,
+        task_goal="查询套餐余量",
+        ledger=DtmfActionLedger(),
+        model="qwen-plus",
+        window_mode="fragmented",
+        throttle_seconds=0.01,
+        timeout_seconds=0.03,
+    )
+    judge.start()
+    judge.submit_remote_transcript("第一段", t_ms=10.0)
+    assert entered.wait(timeout=1)
+    wait_until(
+        lambda: len([kind for kind, _ in record.events if kind == "judge_error"])
+        >= 1
+    )
+
+    for index in range(3):
+        judge.submit_remote_transcript(f"后续段{index}", t_ms=20.0 + index)
+        wait_until(
+            lambda index=index: len(
+                [kind for kind, _ in record.events if kind == "judge_error"]
+            )
+            >= index + 2
+        )
+
+    judge.stop()
+    release.set()
+    assert calls == 1
+
+
 def test_blocked_judge_does_not_block_submit_or_stop_and_stale_result_is_dropped(
     tmp_path,
 ):
@@ -375,6 +435,64 @@ def test_blocked_judge_does_not_block_submit_or_stop_and_stale_result_is_dropped
 
     assert record.events == []
     assert not (record.path / "judge_shadow.jsonl").exists()
+
+
+def test_stop_between_model_result_and_commit_rejects_late_result(tmp_path):
+    entered_commit = threading.Event()
+    release_commit = threading.Event()
+
+    class PausedCommitJudge(DtmfJudge):
+        def _commit_decision(self, generation, decision, latency_ms):
+            entered_commit.set()
+            release_commit.wait(timeout=2)
+            return super()._commit_decision(generation, decision, latency_ms)
+
+    record = SpyRecord(tmp_path / "recording")
+    judge = PausedCommitJudge(
+        record=record,
+        task_goal="查询套餐余量",
+        ledger=DtmfActionLedger(),
+        model="qwen-plus",
+        window_mode="fragmented",
+        model_call=lambda messages, model, timeout: (valid_response(), None),
+        throttle_seconds=0.01,
+    )
+    judge.start()
+    judge.submit_remote_transcript("请按一", t_ms=10.0)
+    assert entered_commit.wait(timeout=1)
+
+    judge.stop(join_timeout=0.01)
+    release_commit.set()
+    time.sleep(0.05)
+
+    assert record.events == []
+    assert not (record.path / "judge_shadow.jsonl").exists()
+
+
+def test_record_action_does_not_do_disk_io_on_the_live_dtmf_path(
+    tmp_path, monkeypatch
+):
+    record = SpyRecord(tmp_path / "recording")
+    ledger = DtmfActionLedger()
+    judge = DtmfJudge(
+        record=record,
+        task_goal="查询套餐余量",
+        ledger=ledger,
+        model="qwen-plus",
+        window_mode="fragmented",
+    )
+    judge.start()
+    real_open = open
+
+    def fail_open(*args, **kwargs):
+        raise AssertionError("record_action must not open files")
+
+    monkeypatch.setattr("builtins.open", fail_open)
+    judge.record_action(ledger.record("1", "realtime", timestamp=1.0))
+    monkeypatch.setattr("builtins.open", real_open)
+    judge.stop()
+
+    assert (record.path / "judge_shadow.jsonl").exists()
 
 
 def test_gitignore_explicitly_covers_private_judge_file():

--- a/tests/unit/test_dtmf_judge.py
+++ b/tests/unit/test_dtmf_judge.py
@@ -1,0 +1,383 @@
+"""DTMF text judge: strict contract, shadow privacy, batching, and lifecycle."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import stat
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from agentcall.dtmf_judge import (
+    DtmfActionLedger,
+    DtmfJudge,
+    JudgeValidationError,
+    build_judge_messages,
+    parse_judge_decision,
+)
+
+
+class SpyRecord:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.path.mkdir(parents=True)
+        self.events: list[tuple[str, dict]] = []
+        self._lock = threading.Lock()
+
+    def log_event(self, event_type: str, **fields) -> None:
+        with self._lock:
+            self.events.append((event_type, fields))
+
+
+def wait_until(predicate, timeout: float = 2.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.01)
+    raise AssertionError("condition was not met before timeout")
+
+
+def valid_response(*, digits: str = "1") -> str:
+    return json.dumps(
+        {
+            "action": "press",
+            "digits": digits,
+            "confidence": 0.97,
+            "reason_code": "menu_matched",
+            "reason": "该选项通向本通任务",
+        },
+        ensure_ascii=False,
+    )
+
+
+def test_parse_judge_decision_accepts_strict_contract():
+    decision = parse_judge_decision(valid_response(digits="103#"))
+
+    assert decision.action == "press"
+    assert decision.digits == "103#"
+    assert decision.confidence == pytest.approx(0.97)
+    assert decision.reason_code == "menu_matched"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "```json\n{}\n```",
+        "not json",
+        json.dumps({"action": "press"}),
+        json.dumps(
+            {
+                "action": "press",
+                "digits": "12345",
+                "confidence": 0.8,
+                "reason_code": "menu_matched",
+                "reason": "x",
+            }
+        ),
+        json.dumps(
+            {
+                "action": "wait",
+                "digits": "1",
+                "confidence": 0.8,
+                "reason_code": "menu_incomplete",
+                "reason": "x",
+            }
+        ),
+        json.dumps(
+            {
+                "action": "wait",
+                "confidence": True,
+                "reason_code": "menu_incomplete",
+                "reason": "x",
+            }
+        ),
+        json.dumps(
+            {
+                "action": "wait",
+                "confidence": math.nan,
+                "reason_code": "menu_incomplete",
+                "reason": "x",
+            }
+        ),
+        json.dumps(
+            {
+                "action": "wait",
+                "confidence": 0.8,
+                "reason_code": "made_up",
+                "reason": "x",
+            }
+        ),
+        json.dumps(
+            {
+                "action": "wait",
+                "confidence": 0.8,
+                "reason_code": "menu_incomplete",
+                "reason": "x" * 51,
+            }
+        ),
+    ],
+)
+def test_parse_judge_decision_rejects_malformed_or_unsafe_payload(payload):
+    with pytest.raises(JudgeValidationError):
+        parse_judge_decision(payload)
+
+
+def test_build_messages_keeps_latest_eight_segments_and_three_actions():
+    ledger = DtmfActionLedger(id_factory=lambda: "action-id")
+    for index in range(4):
+        ledger.record(str(index), "realtime", timestamp=float(index))
+    transcripts = [(float(index * 100), f"segment-{index}") for index in range(10)]
+
+    messages = build_judge_messages(
+        transcripts,
+        ledger.recent(3),
+        "查询套餐余量",
+    )
+    payload = json.loads(messages[1]["content"])
+
+    assert [item["text"] for item in payload["remote_transcripts"]] == [
+        f"segment-{index}" for index in range(2, 10)
+    ]
+    assert [item["digits"] for item in payload["recent_dtmf"]] == ["1", "2", "3"]
+    assert [item["t_ms"] for item in payload["recent_dtmf"]] == [1000.0, 2000.0, 3000.0]
+    assert payload["task_goal"] == "查询套餐余量"
+
+
+def test_ledger_records_three_sources_but_public_fields_have_no_digit_fingerprint():
+    ids = iter(("r-id", "g-id", "j-id"))
+    ledger = DtmfActionLedger(id_factory=lambda: next(ids))
+
+    entries = [
+        ledger.record("1", "realtime", timestamp=1.0),
+        ledger.record("103#", "guard", timestamp=2.0),
+        ledger.record("*", "judge", timestamp=3.0),
+    ]
+
+    assert [entry.source for entry in entries] == ["realtime", "guard", "judge"]
+    assert [entry.digits for entry in ledger.recent(3)] == ["1", "103#", "*"]
+    public = [entry.public_fields() for entry in entries]
+    assert public == [
+        {"action_id": "r-id", "source": "realtime", "digits_len": 1},
+        {"action_id": "g-id", "source": "guard", "digits_len": 4},
+        {"action_id": "j-id", "source": "judge", "digits_len": 1},
+    ]
+    assert "103#" not in repr(public)
+    assert "hash" not in repr(public).lower()
+
+
+def test_private_shadow_file_correlates_cleartext_action_by_opaque_id(tmp_path):
+    record = SpyRecord(tmp_path / "recording")
+    ledger = DtmfActionLedger(id_factory=lambda: "action-opaque")
+    judge = DtmfJudge(
+        record=record,
+        task_goal="查询套餐余量",
+        ledger=ledger,
+        model="qwen-plus",
+        window_mode="fragmented",
+        model_call=lambda messages, model, timeout: (None, "timeout"),
+    )
+    judge.start()
+
+    judge.record_action(ledger.record("103#", "realtime", timestamp=1.25))
+    judge.stop()
+
+    private = json.loads(
+        (record.path / "judge_shadow.jsonl").read_text(encoding="utf-8").strip()
+    )
+    assert private == {
+        "kind": "action",
+        "action_id": "action-opaque",
+        "ts": private["ts"],
+        "t_ms": 1250.0,
+        "source": "realtime",
+        "digits": "103#",
+        "digits_len": 4,
+    }
+    assert isinstance(private["ts"], float)
+
+
+def test_shadow_batches_segments_logs_redacted_event_and_private_digits(tmp_path):
+    record = SpyRecord(tmp_path / "recording")
+    ledger = DtmfActionLedger()
+    calls: list[list[dict[str, str]]] = []
+
+    def model_call(messages, model, timeout):
+        calls.append(messages)
+        return valid_response(digits="103#"), None
+
+    judge = DtmfJudge(
+        record=record,
+        task_goal="查询套餐余量",
+        ledger=ledger,
+        model="qwen-plus",
+        window_mode="merged",
+        model_call=model_call,
+        throttle_seconds=0.03,
+        timeout_seconds=0.2,
+    )
+    judge.start()
+    for index in range(3):
+        judge.submit_remote_transcript(f"菜单片段{index}", t_ms=float(index * 100))
+
+    wait_until(lambda: any(kind == "dtmf_judge" for kind, _ in record.events))
+    judge.stop()
+
+    assert len(calls) == 1
+    model_payload = json.loads(calls[0][1]["content"])
+    assert [item["text"] for item in model_payload["remote_transcripts"]] == [
+        "菜单片段0",
+        "菜单片段1",
+        "菜单片段2",
+    ]
+    events = [fields for kind, fields in record.events if kind == "dtmf_judge"]
+    assert len(events) == 1
+    event = events[0]
+    assert set(event) == {
+        "action",
+        "confidence",
+        "reason_code",
+        "latency_ms",
+        "window_mode",
+        "digits_len",
+        "decision_id",
+    }
+    assert event["digits_len"] == 4
+    assert event["window_mode"] == "merged"
+    assert "103#" not in repr(event)
+    assert "hash" not in repr(event).lower()
+
+    private_path = record.path / "judge_shadow.jsonl"
+    private = json.loads(private_path.read_text(encoding="utf-8").strip())
+    assert private["kind"] == "decision"
+    assert private["decision_id"] == event["decision_id"]
+    assert private["digits"] == "103#"
+    assert private["reason"] == "该选项通向本通任务"
+    if os.name == "posix":
+        assert stat.S_IMODE(private_path.stat().st_mode) == 0o600
+
+
+def test_malformed_model_output_emits_only_sanitized_error(tmp_path):
+    record = SpyRecord(tmp_path / "recording")
+    secret_output = "bad payload containing 103#"
+    judge = DtmfJudge(
+        record=record,
+        task_goal="查询套餐余量",
+        ledger=DtmfActionLedger(),
+        model="qwen-plus",
+        window_mode="fragmented",
+        model_call=lambda messages, model, timeout: (secret_output, None),
+        throttle_seconds=0.01,
+    )
+    judge.start()
+    judge.submit_remote_transcript("请按一", t_ms=10.0)
+
+    wait_until(lambda: any(kind == "judge_error" for kind, _ in record.events))
+    judge.stop()
+
+    errors = [fields for kind, fields in record.events if kind == "judge_error"]
+    assert len(errors) == 1
+    assert set(errors[0]) == {"code", "latency_ms", "window_mode"}
+    assert errors[0]["code"] == "invalid_json"
+    assert secret_output not in repr(record.events)
+    assert not (record.path / "judge_shadow.jsonl").exists()
+
+
+def test_timeout_error_is_sanitized_and_does_not_end_worker(tmp_path):
+    record = SpyRecord(tmp_path / "recording")
+    responses = iter(((None, "timeout"), (valid_response(), None)))
+    judge = DtmfJudge(
+        record=record,
+        task_goal="查询套餐余量",
+        ledger=DtmfActionLedger(),
+        model="qwen-plus",
+        window_mode="merged",
+        model_call=lambda messages, model, timeout: next(responses),
+        throttle_seconds=0.01,
+    )
+    judge.start()
+    judge.submit_remote_transcript("第一段", t_ms=10.0)
+    wait_until(lambda: any(kind == "judge_error" for kind, _ in record.events))
+    judge.submit_remote_transcript("第二段", t_ms=20.0)
+    wait_until(lambda: any(kind == "dtmf_judge" for kind, _ in record.events))
+    judge.stop()
+
+    assert next(fields for kind, fields in record.events if kind == "judge_error")[
+        "code"
+    ] == "timeout"
+
+
+def test_model_call_exceeding_timeout_is_abandoned_without_blocking_worker(tmp_path):
+    record = SpyRecord(tmp_path / "recording")
+    release = threading.Event()
+
+    def slow_call(messages, model, timeout):
+        release.wait(timeout=1)
+        return valid_response(), None
+
+    judge = DtmfJudge(
+        record=record,
+        task_goal="查询套餐余量",
+        ledger=DtmfActionLedger(),
+        model="qwen-plus",
+        window_mode="fragmented",
+        model_call=slow_call,
+        throttle_seconds=0.01,
+        timeout_seconds=0.03,
+    )
+    judge.start()
+    judge.submit_remote_transcript("请按一", t_ms=10.0)
+
+    wait_until(lambda: any(kind == "judge_error" for kind, _ in record.events))
+    judge.stop()
+    release.set()
+
+    error = next(fields for kind, fields in record.events if kind == "judge_error")
+    assert error["code"] == "timeout"
+
+
+def test_blocked_judge_does_not_block_submit_or_stop_and_stale_result_is_dropped(
+    tmp_path,
+):
+    record = SpyRecord(tmp_path / "recording")
+    entered = threading.Event()
+    release = threading.Event()
+
+    def blocked_call(messages, model, timeout):
+        entered.set()
+        release.wait(timeout=10)
+        return valid_response(), None
+
+    judge = DtmfJudge(
+        record=record,
+        task_goal="查询套餐余量",
+        ledger=DtmfActionLedger(),
+        model="qwen-plus",
+        window_mode="fragmented",
+        model_call=blocked_call,
+        throttle_seconds=0.01,
+    )
+    judge.start()
+    started = time.monotonic()
+    judge.submit_remote_transcript("请按一", t_ms=10.0)
+    assert time.monotonic() - started < 0.05
+    assert entered.wait(timeout=1)
+
+    stopped_at = time.monotonic()
+    judge.stop(join_timeout=0.05)
+    assert time.monotonic() - stopped_at < 0.2
+    release.set()
+    time.sleep(0.05)
+
+    assert record.events == []
+    assert not (record.path / "judge_shadow.jsonl").exists()
+
+
+def test_gitignore_explicitly_covers_private_judge_file():
+    root = Path(__file__).resolve().parents[2]
+    text = (root / ".gitignore").read_text(encoding="utf-8")
+    assert "judge_shadow.jsonl" in text

--- a/tests/unit/test_dtmf_judge_wiring.py
+++ b/tests/unit/test_dtmf_judge_wiring.py
@@ -1,0 +1,209 @@
+"""CallSession wiring for the provider-independent DTMF shadow judge."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fakes import FakeAgent, FakeModem
+
+from agentcall.call_agent import CallSession
+
+
+class SpyRecord:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        path.mkdir(parents=True)
+        self.events: list[tuple[str, dict]] = []
+
+    def log_event(self, event_type: str, **fields) -> None:
+        self.events.append((event_type, fields))
+
+
+class FakeJudge:
+    def __init__(self) -> None:
+        self.submitted: list[tuple[str, float]] = []
+        self.stopped = False
+        self.actions = []
+
+    def submit_remote_transcript(self, text: str, *, t_ms: float) -> None:
+        self.submitted.append((text, t_ms))
+
+    def stop(self, *, join_timeout: float = 0.2) -> None:
+        self.stopped = True
+
+    def record_action(self, entry) -> None:
+        self.actions.append(entry)
+
+
+def make_session(*, provider: str = "qwen") -> CallSession:
+    return CallSession(
+        modem=FakeModem(),  # type: ignore[arg-type]
+        audio_keyword="unused",
+        provider=provider,
+        audio_mode="uac",
+        pcm_port=None,
+        pcm_baudrate=921600,
+        tx_gain=1.0,
+    )
+
+
+def test_judge_off_creates_no_worker(tmp_path, monkeypatch):
+    monkeypatch.setenv("DTMF_JUDGE_MODE", "off")
+    session = make_session()
+    record = SpyRecord(tmp_path / "call")
+
+    session._start_dtmf_judge(record, session_t0=10.0)
+
+    assert session._dtmf_judge is None
+
+
+def test_shadow_start_failure_does_not_fail_call_session(tmp_path, monkeypatch):
+    class BrokenJudge:
+        def __init__(self, **kwargs) -> None:
+            raise RuntimeError("model setup leaked menu text")
+
+    monkeypatch.setenv("DTMF_JUDGE_MODE", "shadow")
+    monkeypatch.setattr("agentcall.call_agent.DtmfJudge", BrokenJudge)
+    session = make_session()
+    record = SpyRecord(tmp_path / "call")
+
+    session._start_dtmf_judge(record, session_t0=10.0)
+
+    assert session._dtmf_judge is None
+    assert record.events == [
+        (
+            "judge_error",
+            {"code": "startup_error", "latency_ms": 0.0, "window_mode": "fragmented"},
+        )
+    ]
+    assert "model setup leaked menu text" not in repr(record.events)
+
+
+def test_shadow_uses_model_fallback_and_mrc_window_mode(tmp_path, monkeypatch):
+    captured: dict[str, object] = {}
+
+    class CapturingJudge:
+        def __init__(self, **kwargs) -> None:
+            captured.update(kwargs)
+
+        def start(self) -> None:
+            captured["started"] = True
+
+        def stop(self, *, join_timeout: float = 0.2) -> None:
+            captured["stopped"] = True
+
+    monkeypatch.setenv("DTMF_JUDGE_MODE", "shadow")
+    monkeypatch.setenv("DTMF_JUDGE_MODEL", "")
+    monkeypatch.setenv("PROMPT_GEN_MODEL", "qwen-custom")
+    monkeypatch.setenv("MANUAL_RESPONSE_CONTROL", "true")
+    monkeypatch.setattr("agentcall.call_agent.DtmfJudge", CapturingJudge)
+    session = make_session(provider="openai")
+    session._outbound_number = "10000"
+    session._outbound_task_value = "查询套餐余量"
+    record = SpyRecord(tmp_path / "call")
+
+    session._start_dtmf_judge(record, session_t0=10.0)
+
+    assert captured["record"] is record
+    assert captured["task_goal"] == "查询套餐余量"
+    assert captured["model"] == "qwen-custom"
+    assert captured["window_mode"] == "merged"
+    assert captured["ledger"] is session._dtmf_ledger
+    assert captured["started"] is True
+
+
+@pytest.mark.parametrize("provider", ["qwen", "openai", "local"])
+def test_remote_transcripts_feed_same_shadow_hook_for_all_providers(
+    provider, tmp_path
+):
+    session = make_session(provider=provider)
+    session._active = True
+    session._session_generation = 7
+    session._dtmf_judge_started_at = 100.0
+    judge = FakeJudge()
+    session._dtmf_judge = judge  # type: ignore[assignment]
+    record = SpyRecord(tmp_path / provider)
+    transcripts: list[tuple[str, str]] = []
+    handler = session._make_transcript_handler(record, transcripts, FakeAgent())
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr("agentcall.call_agent.time.monotonic", lambda: 100.25)
+        handler("user", "请按一查询")
+        handler("agent", "我先听菜单")
+
+    assert judge.submitted == [("请按一查询", 250.0)]
+
+
+def test_session_stop_invalidates_judge_worker():
+    session = make_session()
+    judge = FakeJudge()
+    session._dtmf_judge = judge  # type: ignore[assignment]
+    session._active = True
+
+    session.stop()
+
+    assert judge.stopped is True
+    assert session._dtmf_judge is None
+
+
+def test_sent_dtmf_records_redacted_action_ledger_for_three_sources(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("DTMF_MODE", "qvts")
+    session = make_session()
+    session._record = SpyRecord(tmp_path / "call")  # type: ignore[assignment]
+
+    for digits, source in (
+        ("1", "agent_tool"),
+        ("2", "spoken_followup"),
+        ("3", "judge"),
+    ):
+        ok, _mode = session._send_dtmf_raw(digits, source=source)
+        assert ok
+
+    entries = session._dtmf_ledger.recent(3)
+    assert [entry.source for entry in entries] == ["realtime", "guard", "judge"]
+    events = [fields for kind, fields in session._record.events if kind == "dtmf_action"]
+    assert [event["source"] for event in events] == ["realtime", "guard", "judge"]
+    assert [event["digits_len"] for event in events] == [1, 1, 1]
+    assert all("digits" not in event and "hash" not in repr(event).lower() for event in events)
+    assert "1" not in {event.get("digits") for event in events}
+
+
+def test_sent_dtmf_notifies_shadow_private_ledger(tmp_path, monkeypatch):
+    monkeypatch.setenv("DTMF_MODE", "qvts")
+    session = make_session()
+    session._record = SpyRecord(tmp_path / "call")  # type: ignore[assignment]
+    judge = FakeJudge()
+    session._dtmf_judge = judge  # type: ignore[assignment]
+
+    ok, _mode = session._send_dtmf_raw("1", source="agent_tool")
+
+    assert ok
+    assert len(judge.actions) == 1
+    assert judge.actions[0].source == "realtime"
+    assert judge.actions[0].digits == "1"
+
+
+def test_shadow_judge_has_no_dispatch_dependency(tmp_path):
+    """The Phase-S component cannot press a key because no tools enter its API."""
+    from agentcall.dtmf_judge import DtmfActionLedger, DtmfJudge
+
+    record = SpyRecord(tmp_path / "call")
+    judge = DtmfJudge(
+        record=record,
+        task_goal="查询套餐余量",
+        ledger=DtmfActionLedger(),
+        model="qwen-plus",
+        window_mode="fragmented",
+        model_call=lambda messages, model, timeout: (
+            '{"action":"press","digits":"1","confidence":1.0,'
+            '"reason_code":"menu_matched","reason":"明确菜单"}',
+            None,
+        ),
+        throttle_seconds=0.01,
+    )
+
+    assert not hasattr(judge, "tools")
+    assert not hasattr(judge, "dispatch")

--- a/tests/unit/test_dtmf_judge_wiring.py
+++ b/tests/unit/test_dtmf_judge_wiring.py
@@ -8,6 +8,7 @@ import pytest
 from fakes import FakeAgent, FakeModem
 
 from agentcall.call_agent import CallSession
+from agentcall.dtmf_judge import DtmfActionLedger
 
 
 class SpyRecord:
@@ -56,6 +57,13 @@ def test_judge_off_creates_no_worker(tmp_path, monkeypatch):
     session._start_dtmf_judge(record, session_t0=10.0)
 
     assert session._dtmf_judge is None
+    assert session._dtmf_ledger is None
+
+    session._record = record  # type: ignore[assignment]
+    monkeypatch.setenv("DTMF_MODE", "qvts")
+    ok, _mode = session._send_dtmf_raw("1", source="agent_tool")
+    assert ok
+    assert record.events == []
 
 
 def test_shadow_start_failure_does_not_fail_call_session(tmp_path, monkeypatch):
@@ -150,9 +158,12 @@ def test_session_stop_invalidates_judge_worker():
 def test_sent_dtmf_records_redacted_action_ledger_for_three_sources(
     tmp_path, monkeypatch
 ):
+    monkeypatch.setenv("DTMF_JUDGE_MODE", "shadow")
     monkeypatch.setenv("DTMF_MODE", "qvts")
     session = make_session()
     session._record = SpyRecord(tmp_path / "call")  # type: ignore[assignment]
+    session._dtmf_ledger = DtmfActionLedger()
+    session._dtmf_judge = FakeJudge()  # type: ignore[assignment]
 
     for digits, source in (
         ("1", "agent_tool"),
@@ -177,6 +188,7 @@ def test_sent_dtmf_notifies_shadow_private_ledger(tmp_path, monkeypatch):
     session._record = SpyRecord(tmp_path / "call")  # type: ignore[assignment]
     judge = FakeJudge()
     session._dtmf_judge = judge  # type: ignore[assignment]
+    session._dtmf_ledger = DtmfActionLedger()
 
     ok, _mode = session._send_dtmf_raw("1", source="agent_tool")
 

--- a/tests/unit/test_regression_call.py
+++ b/tests/unit/test_regression_call.py
@@ -201,6 +201,9 @@ def test_dtmf_judge_shadow_reports_exact_match_without_exposing_digits():
             "dtmf_judge",
             decision_id="decision-a",
             action="press",
+            confidence=0.9,
+            reason_code="menu_matched",
+            latency_ms=12.0,
             digits_len=1,
             window_mode="merged",
             ts=5.0,
@@ -219,6 +222,10 @@ def test_dtmf_judge_shadow_reports_exact_match_without_exposing_digits():
             "decision_id": "decision-a",
             "action": "press",
             "digits": "7",
+            "confidence": 0.9,
+            "reason_code": "menu_matched",
+            "reason": "明确菜单",
+            "latency_ms": 12.0,
             "ts": 5.0,
             "window_mode": "merged",
         },
@@ -227,7 +234,9 @@ def test_dtmf_judge_shadow_reports_exact_match_without_exposing_digits():
             "action_id": "action-a",
             "source": "realtime",
             "digits": "7",
+            "digits_len": 1,
             "ts": 5.5,
+            "t_ms": 500.0,
         },
     ]
 
@@ -244,6 +253,9 @@ def test_dtmf_judge_shadow_disagreement_is_warning_not_gate_failure():
             "dtmf_judge",
             decision_id="decision-a",
             action="press",
+            confidence=0.9,
+            reason_code="menu_matched",
+            latency_ms=12.0,
             digits_len=1,
             window_mode="fragmented",
             ts=5.0,
@@ -255,6 +267,10 @@ def test_dtmf_judge_shadow_disagreement_is_warning_not_gate_failure():
             "decision_id": "decision-a",
             "action": "press",
             "digits": "7",
+            "confidence": 0.9,
+            "reason_code": "menu_matched",
+            "reason": "明确菜单",
+            "latency_ms": 12.0,
             "ts": 5.0,
             "window_mode": "fragmented",
         }
@@ -265,6 +281,122 @@ def test_dtmf_judge_shadow_disagreement_is_warning_not_gate_failure():
     assert result.status == "WARN"
     assert "no_action=1" in result.detail
     assert "7" not in result.detail
+
+
+def test_dtmf_judge_shadow_wait_followed_by_press_is_not_false_pass():
+    events = _base_events(
+        _event(
+            "dtmf_judge",
+            decision_id="decision-a",
+            action="wait",
+            confidence=0.8,
+            reason_code="menu_incomplete",
+            latency_ms=12.0,
+            digits_len=0,
+            window_mode="merged",
+            ts=5.0,
+        ),
+        _event(
+            "dtmf_action",
+            action_id="action-a",
+            source="realtime",
+            digits_len=1,
+            ts=5.5,
+        ),
+    )
+    private = [
+        {
+            "kind": "decision",
+            "decision_id": "decision-a",
+            "action": "wait",
+            "digits": None,
+            "confidence": 0.8,
+            "reason_code": "menu_incomplete",
+            "reason": "菜单未完",
+            "latency_ms": 12.0,
+            "window_mode": "merged",
+            "ts": 5.0,
+        },
+        {
+            "kind": "action",
+            "action_id": "action-a",
+            "source": "realtime",
+            "digits": "7",
+            "digits_len": 1,
+            "ts": 5.5,
+            "t_ms": 500.0,
+        },
+    ]
+
+    result = regression_call.check_dtmf_judge_shadow(events, private)
+
+    assert result.status == "WARN"
+    assert "unexpected_action=1" in result.detail
+    assert "7" not in result.detail
+
+
+@pytest.mark.parametrize(
+    ("public_override", "private_override"),
+    [
+        ({"digits_len": 2}, {}),
+        ({"action": "wait"}, {}),
+        ({"window_mode": "banana"}, {}),
+        ({}, {"window_mode": "banana"}),
+    ],
+)
+def test_dtmf_judge_shadow_rejects_public_private_schema_mismatch(
+    public_override, private_override
+):
+    public = {
+        "type": "dtmf_judge",
+        "decision_id": "decision-a",
+        "action": "press",
+        "confidence": 0.9,
+        "reason_code": "menu_matched",
+        "latency_ms": 12.0,
+        "digits_len": 1,
+        "window_mode": "merged",
+        "ts": 5.0,
+        **public_override,
+    }
+    private = {
+        "kind": "decision",
+        "decision_id": "decision-a",
+        "action": "press",
+        "digits": "7",
+        "confidence": 0.9,
+        "reason_code": "menu_matched",
+        "reason": "明确菜单",
+        "latency_ms": 12.0,
+        "window_mode": "merged",
+        "ts": 5.0,
+        **private_override,
+    }
+
+    result = regression_call.check_dtmf_judge_shadow(
+        _base_events(public), [private]
+    )
+
+    assert result.status == "WARN"
+    assert "schema_errors=" in result.detail
+    assert "7" not in result.detail
+
+
+def test_dtmf_judge_shadow_errors_without_decisions_warn():
+    events = _base_events(
+        _event(
+            "judge_error",
+            code="timeout",
+            latency_ms=3000.0,
+            window_mode="fragmented",
+            ts=5.0,
+        )
+    )
+
+    result = regression_call.check_dtmf_judge_shadow(events, [])
+
+    assert result.status == "WARN"
+    assert "errors=1" in result.detail
 
 
 def test_load_judge_shadow_is_optional_and_validates_jsonl(tmp_path):

--- a/tests/unit/test_regression_call.py
+++ b/tests/unit/test_regression_call.py
@@ -399,6 +399,94 @@ def test_dtmf_judge_shadow_errors_without_decisions_warn():
     assert "errors=1" in result.detail
 
 
+def test_dtmf_judge_shadow_rejects_public_private_timestamp_rewrite():
+    events = _base_events(
+        _event(
+            "dtmf_judge",
+            decision_id="decision-a",
+            action="press",
+            confidence=0.9,
+            reason_code="menu_matched",
+            latency_ms=12.0,
+            digits_len=1,
+            window_mode="merged",
+            ts=5.0,
+        ),
+        _event(
+            "dtmf_action",
+            action_id="action-a",
+            source="realtime",
+            digits_len=1,
+            ts=100.0,
+        ),
+    )
+    private = [
+        {
+            "kind": "decision",
+            "decision_id": "decision-a",
+            "action": "press",
+            "digits": "7",
+            "confidence": 0.9,
+            "reason_code": "menu_matched",
+            "reason": "明确菜单",
+            "latency_ms": 12.0,
+            "window_mode": "merged",
+            "ts": 5.0,
+        },
+        {
+            "kind": "action",
+            "action_id": "action-a",
+            "source": "realtime",
+            "digits": "7",
+            "digits_len": 1,
+            "ts": 5.1,
+            "t_ms": 100.0,
+        },
+    ]
+
+    result = regression_call.check_dtmf_judge_shadow(events, private)
+
+    assert result.status == "WARN"
+    assert "schema_errors=1" in result.detail
+    assert "7" not in result.detail
+
+
+def test_dtmf_judge_shadow_rejects_unknown_private_record_kind():
+    events = _base_events(
+        _event(
+            "dtmf_judge",
+            decision_id="decision-a",
+            action="wait",
+            confidence=0.8,
+            reason_code="menu_incomplete",
+            latency_ms=12.0,
+            digits_len=0,
+            window_mode="merged",
+            ts=5.0,
+        )
+    )
+    private = [
+        {
+            "kind": "decision",
+            "decision_id": "decision-a",
+            "action": "wait",
+            "digits": None,
+            "confidence": 0.8,
+            "reason_code": "menu_incomplete",
+            "reason": "菜单未完",
+            "latency_ms": 12.0,
+            "window_mode": "merged",
+            "ts": 5.0,
+        },
+        {"kind": "mystery", "ts": 5.1},
+    ]
+
+    result = regression_call.check_dtmf_judge_shadow(events, private)
+
+    assert result.status == "WARN"
+    assert "schema_errors=1" in result.detail
+
+
 def test_load_judge_shadow_is_optional_and_validates_jsonl(tmp_path):
     assert regression_call.load_judge_shadow(tmp_path) == []
     path = tmp_path / "judge_shadow.jsonl"

--- a/tests/unit/test_regression_call.py
+++ b/tests/unit/test_regression_call.py
@@ -4,6 +4,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from scripts import regression_call
@@ -191,6 +193,91 @@ def test_dtmf_without_remote_transcript_in_observation_window_warns():
     assert result.status == "WARN"
     assert "8s" in result.detail
     assert "9.1s" in result.detail
+
+
+def test_dtmf_judge_shadow_reports_exact_match_without_exposing_digits():
+    events = _base_events(
+        _event(
+            "dtmf_judge",
+            decision_id="decision-a",
+            action="press",
+            digits_len=1,
+            window_mode="merged",
+            ts=5.0,
+        ),
+        _event(
+            "dtmf_action",
+            action_id="action-a",
+            source="realtime",
+            digits_len=1,
+            ts=5.5,
+        ),
+    )
+    private = [
+        {
+            "kind": "decision",
+            "decision_id": "decision-a",
+            "action": "press",
+            "digits": "7",
+            "ts": 5.0,
+            "window_mode": "merged",
+        },
+        {
+            "kind": "action",
+            "action_id": "action-a",
+            "source": "realtime",
+            "digits": "7",
+            "ts": 5.5,
+        },
+    ]
+
+    result = regression_call.check_dtmf_judge_shadow(events, private)
+
+    assert result.status == "PASS"
+    assert "exact=1" in result.detail
+    assert "7" not in result.detail
+
+
+def test_dtmf_judge_shadow_disagreement_is_warning_not_gate_failure():
+    events = _base_events(
+        _event(
+            "dtmf_judge",
+            decision_id="decision-a",
+            action="press",
+            digits_len=1,
+            window_mode="fragmented",
+            ts=5.0,
+        )
+    )
+    private = [
+        {
+            "kind": "decision",
+            "decision_id": "decision-a",
+            "action": "press",
+            "digits": "7",
+            "ts": 5.0,
+            "window_mode": "fragmented",
+        }
+    ]
+
+    result = regression_call.check_dtmf_judge_shadow(events, private)
+
+    assert result.status == "WARN"
+    assert "no_action=1" in result.detail
+    assert "7" not in result.detail
+
+
+def test_load_judge_shadow_is_optional_and_validates_jsonl(tmp_path):
+    assert regression_call.load_judge_shadow(tmp_path) == []
+    path = tmp_path / "judge_shadow.jsonl"
+    path.write_text('{"kind":"decision","digits":"1"}\n', encoding="utf-8")
+    assert regression_call.load_judge_shadow(tmp_path) == [
+        {"kind": "decision", "digits": "1"}
+    ]
+
+    path.write_text("not-json\n", encoding="utf-8")
+    with pytest.raises(regression_call.RegressionError):
+        regression_call.load_judge_shadow(tmp_path)
 
 
 def test_agent_repeats_user_supplied_value_passes_fabrication_check():


### PR DESCRIPTION
#80 治本方案第一阶段:文本判官(qwen-plus)shadow 模式——对方转写流驱动,专职判断「此刻是否该按键、按几」,**只落 dtmf_judge 事件,不执行任何按键**;为 Phase E(接管)采集判官自身准确率数据。

规格:三方定稿 v0.3(shadow 达标线召回≥90%/误按≤5% 仅评估资格;Phase E 接管门槛误按=0)。

关键实现(codex,双路独立 review APPROVE):
- 隐私:公开事件/ledger 零 digits 派生物(域≤20736,hash 可枚举反推),digits_len+随机 decision_id;明文仅落 record.path/judge_shadow.jsonl(随 CallLogger 保留期清理)
- 进程级模型 single-flight、跨通生命周期隔离、off 模式零开销、严格 JSON 校验、判官卡死不阻塞音频热循环
- \`DTMF_JUDGE_MODE\`=off(默认)|shadow;enforce 本批配置层拒绝

验证:887 passed / ruff / mypy / Windows mypy / 敏感扫描全过。

- Draft 待 CI 三平台;merge 待 owner 批;merge 后真机窗口采 shadow 数据

Refs #80 #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3ym8uHa4Xq46rZBDCXaDb