### PR TITLE
feat: SIM 运营商识别与展示(诊断层,Refs #88)

### DIFF
--- a/src/agentcall/modem.py
+++ b/src/agentcall/modem.py
@@ -11,6 +11,7 @@ from typing import Callable
 import serial
 
 from . import config, platforms, port_detect
+from .sim_identity import UNKNOWN_SIM, SimIdentity, identify
 
 logger = logging.getLogger(__name__)
 
@@ -163,6 +164,8 @@ class Eg25Modem:
         self.baudrate = baudrate
         # port 为 auto 哨兵时每次打开都重新探测，这里存本次解析出的实际端口（供日志）。
         self._active_port: str | None = None
+        # SIM 身份缓存(#88):连接/重连后读一次 CIMI/CREG;换卡靠重插/重连触发刷新。
+        self._sim_identity: SimIdentity = UNKNOWN_SIM
         self._ser: serial.Serial | None = None
         self._reader_thread: threading.Thread | None = None
         self._poll_thread: threading.Thread | None = None
@@ -214,6 +217,57 @@ class Eg25Modem:
         """
         return self._send(command)
 
+    # SIM 上电后 CIMI 可能短暂 ERROR(卡未 ready);重试覆盖上电延迟。
+    _SIM_READ_RETRIES = 3
+    _SIM_READ_RETRY_DELAY = 1.0
+
+    def refresh_sim_identity(self) -> None:
+        """读 CIMI/CREG 刷新 SIM 身份缓存(#88);AT 逻辑失败降级为 UNKNOWN_SIM,
+        传输层故障上抛。connect/重连(``_open_serial``,已持串口锁)自动调用,
+        换卡经拔插重连天然刷新;也可被上层主动调用重刷。
+
+        已知限制(follow-up):不拔卡热换 SIM、注册状态后续变化不会自动上报刷新
+        (需 +QSIMSTAT / +CREG=1 URC,列入 #88 follow-up)。CIMI 上电延迟已由
+        本方法内短重试覆盖。
+        """
+        imsi_raw = ""
+        for attempt in range(self._SIM_READ_RETRIES):
+            try:
+                imsi_raw = self._send("AT+CIMI")
+            except (serial.SerialException, OSError):
+                # 传输层故障必须上抛给 _open_serial 的退避循环——不能吞成"识别失败"
+                # 而让重连误判成功(codex #88 review BLOCK-3)。
+                self._sim_identity = UNKNOWN_SIM
+                raise
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("SIM CIMI 读取异常: %s", type(exc).__name__)
+                imsi_raw = ""
+            if identify(imsi_raw).present:
+                break  # 卡已 ready,不必再等
+            if attempt < self._SIM_READ_RETRIES - 1:
+                time.sleep(self._SIM_READ_RETRY_DELAY)  # 卡未 ready,等上电
+        try:
+            creg_raw = self._send("AT+CREG?")
+        except (serial.SerialException, OSError):
+            self._sim_identity = UNKNOWN_SIM
+            raise
+        except Exception:  # noqa: BLE001
+            creg_raw = ""
+        self._sim_identity = identify(imsi_raw, creg_raw)
+        sim = self._sim_identity
+        if sim.present:
+            logger.info(
+                "SIM 识别: %s (PLMN %s) → 免费客服 %s | 网络: %s",
+                sim.carrier, sim.plmn, sim.service_number or "?", sim.reg_status,
+            )
+        else:
+            logger.warning("SIM 识别失败(未插卡/未就绪): %s", sim.reg_status)
+
+    @property
+    def sim_identity(self) -> SimIdentity:
+        """最近一次连接/重连时读到的 SIM 身份(缓存,不触发 AT)。"""
+        return self._sim_identity
+
     def _resolve_port(self) -> str:
         """把 auto 哨兵解析为实际串口；每次打开都重扫（Windows 重插后 COM 号会变）。
 
@@ -245,6 +299,7 @@ class Eg25Modem:
                 self._send("ATE0")
                 self._send("AT+CLIP=1")
                 self._init_sms()
+                self.refresh_sim_identity()
             finally:
                 self._opening = False
 

--- a/src/agentcall/sim_identity.py
+++ b/src/agentcall/sim_identity.py
@@ -1,0 +1,118 @@
+"""SIM 卡运营商识别:IMSI(PLMN 前缀)→ 运营商 → 免费客服号。
+
+背景(issue #88):开发/使用中会换卡,系统不感知运营商变化——测试拨号目标
+(免费客服热线)随卡而变,拨错跨运营商客服号会按普通通话计费(2026-07-13
+实测);换卡后一段时间网络未注册,拨号 45s 超时而用户无从自诊。
+
+本模块只做纯函数解析(可独测):IMSI/CREG 原始响应 → 结构化身份。
+PLMN(MCC+MNC)→ 运营商映射是公开电信标准的确定性事实数据,不属于
+「对话逻辑枚举」,不违反项目非枚举硬原则。
+
+AT 交互与缓存在 modem 层(Eg25Modem.refresh_sim_identity)。
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass
+
+# 中国大陆四大运营商 PLMN(MCC=460 + MNC)。来源:公开号段分配(ITU/工信部),
+# 与 ~/.claude skill callpilot-sim-check、issue #72/#88 一致。
+_PLMN_CARRIERS: dict[str, str] = {
+    # 中国移动
+    "46000": "中国移动", "46002": "中国移动", "46004": "中国移动",
+    "46007": "中国移动", "46008": "中国移动", "46013": "中国移动",
+    # 中国联通
+    "46001": "中国联通", "46006": "中国联通", "46009": "中国联通",
+    # 中国电信
+    "46003": "中国电信", "46005": "中国电信", "46011": "中国电信",
+    "46012": "中国电信",
+    # 中国广电(工信部第四家基础运营商,700MHz)
+    "46015": "中国广电",
+}
+
+# 运营商 → 免费客服热线(真机拨测唯一允许的目标,见 CLAUDE.md 硬约束)。
+_SERVICE_NUMBERS: dict[str, str] = {
+    "中国移动": "10086",
+    "中国联通": "10010",
+    "中国电信": "10000",
+    "中国广电": "10099",
+}
+
+_IMSI_RE = re.compile(r"\b(\d{14,15})\b")
+_CREG_RE = re.compile(r"\+CREG:\s*\d+\s*,\s*(\d+)")
+
+# CREG <stat> 语义(3GPP TS 27.007):1=已注册(本地),5=已注册(漫游)。
+_REGISTERED_STATS = {"1", "5"}
+_CREG_LABELS = {
+    "0": "未注册",
+    "1": "已注册",
+    "2": "搜网中",
+    "3": "注册被拒",
+    "4": "未知",
+    "5": "已注册(漫游)",
+}
+
+
+@dataclass(frozen=True)
+class SimIdentity:
+    """一张 SIM 的结构化身份;字段全部可安全对外(不含完整 IMSI)。"""
+
+    present: bool            # 是否成功读到 SIM(CIMI 有响应)
+    plmn: str                # IMSI 前 5 位(如 46011);未读到为 ""
+    carrier: str             # 运营商中文名;未识别为 "未知"
+    service_number: str      # 该运营商免费客服号;未识别为 ""
+    registered: bool         # CS 域已注册(CREG 1/5)
+    reg_status: str          # 注册状态人话(已注册/搜网中/…)
+
+    def as_dict(self) -> dict:
+        return asdict(self)
+
+
+UNKNOWN_SIM = SimIdentity(
+    present=False, plmn="", carrier="未知", service_number="",
+    registered=False, reg_status="未知",
+)
+
+
+def parse_imsi(raw: str) -> str:
+    """从 AT+CIMI 原始响应提取 IMSI(14-15 位数字);无则返回 ""。
+
+    响应形如 ``460110123456789\\r\\n\\r\\nOK``;ERROR/+CME ERROR(SIM 未插/
+    未就绪)则匹配不到数字串。
+    """
+    if not raw or "ERROR" in raw.upper():
+        return ""
+    m = _IMSI_RE.search(raw)
+    return m.group(1) if m else ""
+
+
+def parse_creg(raw: str) -> tuple[bool, str]:
+    """从 AT+CREG? 原始响应解析 (是否已注册, 状态人话)。"""
+    m = _CREG_RE.search(raw or "")
+    if not m:
+        return False, "未知"
+    stat = m.group(1)
+    return stat in _REGISTERED_STATS, _CREG_LABELS.get(stat, f"状态{stat}")
+
+
+def identify(imsi_raw: str, creg_raw: str = "") -> SimIdentity:
+    """由 CIMI/CREG 原始响应合成 SimIdentity(纯函数,幂等)。"""
+    imsi = parse_imsi(imsi_raw)
+    if not imsi:
+        registered, reg_status = parse_creg(creg_raw)
+        return SimIdentity(
+            present=False, plmn="", carrier="未知", service_number="",
+            registered=registered, reg_status=reg_status,
+        )
+    plmn = imsi[:5]
+    carrier = _PLMN_CARRIERS.get(plmn, "未知")
+    registered, reg_status = parse_creg(creg_raw)
+    return SimIdentity(
+        present=True,
+        plmn=plmn,
+        carrier=carrier,
+        service_number=_SERVICE_NUMBERS.get(carrier, ""),
+        registered=registered,
+        reg_status=reg_status,
+    )

--- a/src/agentcall/web/server.py
+++ b/src/agentcall/web/server.py
@@ -349,6 +349,11 @@ async def _meta(request: web.Request) -> web.Response:
         "modem_connected": bool(getattr(service, "modem_connected", False)),
         "port": meta.get("port") or config.get_str("MODEM_PORT"),
     }
+    # SIM 身份(#88):运营商/免费客服号/注册状态——换卡后 UI 与拨测目标自适应。
+    modem = getattr(service, "modem", None)
+    sim = getattr(modem, "sim_identity", None)
+    if sim is not None:
+        meta["sim"] = sim.as_dict()
     # 录音根目录的单一事实出处：外部工具（回归脚本等）从这里拿，
     # 避免开发版/打包版数据目录不一致导致对着空目录空等（issue #15）。
     call_logger = getattr(service, "call_logger", None)

--- a/src/agentcall/web/static/index.html
+++ b/src/agentcall/web/static/index.html
@@ -1285,7 +1285,7 @@ const I18N = {
     setup_skip_all: "Skip setup", setup_skip_step: "Skip step", setup_back: "Back", setup_next: "Next",
     setup_finish: "Finish", setup_steps: ["Hardware", "API Key", "Personalize", "Recording", "Self-test", "Done"],
     setup_hw_title: "Hardware check", setup_hw_hint: "Plug in the EC20/EG25 module and keep the AT port connected. This check does not block setup.",
-    setup_usb: "USB module", setup_at: "AT port", setup_port: "Port",
+    setup_usb: "USB module", setup_at: "AT port", setup_port: "Port", setup_sim: "SIM",
     setup_hw_ok: "Hardware looks ready.", setup_hw_wait: "Hardware is not fully ready yet. You can continue and retry after plugging it in.",
     setup_key_title: "Provider API key", setup_key_hint: "Qwen and OpenAI keys are validated online before saving. The key is never echoed back.",
     setup_qwen_key_help: {
@@ -1454,7 +1454,7 @@ const I18N = {
     setup_skip_all: "跳过向导", setup_skip_step: "跳过本步", setup_back: "上一步", setup_next: "下一步",
     setup_finish: "完成", setup_steps: ["硬件", "API Key", "个性化", "通话录音", "自测", "完成"],
     setup_hw_title: "硬件检测", setup_hw_hint: "请插入 EC20/EG25 模组并保持 AT 口连接。本检测不阻塞后续配置。",
-    setup_usb: "USB 模组", setup_at: "AT 口", setup_port: "端口",
+    setup_usb: "USB 模组", setup_at: "AT 口", setup_port: "端口", setup_sim: "SIM 卡",
     setup_hw_ok: "硬件状态看起来已就绪。", setup_hw_wait: "硬件暂未完全就绪。你可以继续配置，插好后再重试。",
     setup_key_title: "Provider API Key", setup_key_hint: "Qwen 与 OpenAI 会先在线校验再保存；Key 不会被回显。",
     setup_qwen_key_help: {
@@ -2755,10 +2755,15 @@ function renderSetupHardware() {
   const box = $("setupHardware");
   if (!box) return;
   box.textContent = "";
+  const sim = meta.sim || {};
+  const simText = sim.present
+    ? `${sim.carrier} · ${sim.reg_status}` + (sim.service_number ? ` · 客服 ${sim.service_number}` : "")
+    : "-";
   for (const [label, value] of [
     [t("setup_usb"), statusWord(!!hw.usb_online)],
     [t("setup_at"), statusWord(!!hw.modem_connected)],
     [t("setup_port"), hw.port || "-"],
+    [t("setup_sim"), simText],
   ]) {
     const row = el("div", "line");
     row.appendChild(el("b", "", label));

--- a/tests/unit/test_sim_identity.py
+++ b/tests/unit/test_sim_identity.py
@@ -1,0 +1,168 @@
+"""sim_identity 纯函数单测(#88):IMSI/CREG 解析与运营商映射。"""
+
+from __future__ import annotations
+
+from agentcall.sim_identity import (
+    UNKNOWN_SIM,
+    identify,
+    parse_creg,
+    parse_imsi,
+)
+
+# ---- parse_imsi ----
+
+def test_parse_imsi_typical_response():
+    assert parse_imsi("460110123456789\r\n\r\nOK") == "460110123456789"
+
+
+def test_parse_imsi_14_digit_supported():
+    assert parse_imsi("46011012345678\r\nOK") == "46011012345678"
+
+
+def test_parse_imsi_error_and_garbage_rejected():
+    assert parse_imsi("+CME ERROR: SIM not inserted") == ""
+    assert parse_imsi("ERROR") == ""
+    assert parse_imsi("") == ""
+    assert parse_imsi("OK") == ""
+    # 13 位太短不是 IMSI
+    assert parse_imsi("4601101234567\r\nOK") == ""
+
+
+# ---- parse_creg ----
+
+def test_parse_creg_registered_states():
+    assert parse_creg("+CREG: 0,1\r\nOK") == (True, "已注册")
+    assert parse_creg("+CREG: 0,5\r\nOK") == (True, "已注册(漫游)")
+
+
+def test_parse_creg_searching_and_denied():
+    assert parse_creg("+CREG: 0,2\r\nOK") == (False, "搜网中")
+    assert parse_creg("+CREG: 0,3\r\nOK") == (False, "注册被拒")
+    assert parse_creg("+CREG: 0,0") == (False, "未注册")
+
+
+def test_parse_creg_malformed():
+    assert parse_creg("") == (False, "未知")
+    assert parse_creg("ERROR") == (False, "未知")
+
+
+# ---- identify:四大运营商映射(全 PLMN 表逐条锁死)----
+
+def test_identify_all_known_plmns():
+    expect = {
+        "46000": ("中国移动", "10086"), "46002": ("中国移动", "10086"),
+        "46004": ("中国移动", "10086"), "46007": ("中国移动", "10086"),
+        "46008": ("中国移动", "10086"), "46013": ("中国移动", "10086"),
+        "46001": ("中国联通", "10010"), "46006": ("中国联通", "10010"),
+        "46009": ("中国联通", "10010"),
+        "46003": ("中国电信", "10000"), "46005": ("中国电信", "10000"),
+        "46011": ("中国电信", "10000"), "46012": ("中国电信", "10000"),
+        "46015": ("中国广电", "10099"),
+    }
+    for plmn, (carrier, svc) in expect.items():
+        sim = identify(f"{plmn}0123456789\r\nOK", "+CREG: 0,1")
+        assert (sim.carrier, sim.service_number) == (carrier, svc), plmn
+        assert sim.present and sim.plmn == plmn and sim.registered
+
+
+def test_identify_unknown_plmn_no_service_number():
+    sim = identify("310150123456789\r\nOK", "+CREG: 0,1")  # 美国运营商
+    assert sim.present and sim.carrier == "未知" and sim.service_number == ""
+
+
+def test_identify_no_sim_keeps_creg_info():
+    sim = identify("+CME ERROR: SIM not inserted", "+CREG: 0,2")
+    assert not sim.present
+    assert sim.carrier == "未知" and sim.service_number == ""
+    assert not sim.registered and sim.reg_status == "搜网中"
+
+
+def test_identify_as_dict_has_no_full_imsi():
+    """as_dict 只暴露 PLMN 前缀,绝不含完整 IMSI(隐私)。"""
+    sim = identify("460110123456789\r\nOK", "+CREG: 0,1")
+    d = sim.as_dict()
+    assert d["plmn"] == "46011"
+    assert "460110123456789" not in str(d)
+
+
+def test_unknown_sim_sentinel():
+    assert not UNKNOWN_SIM.present
+    assert UNKNOWN_SIM.as_dict()["carrier"] == "未知"
+
+
+# ---- modem 层接线(#88):refresh_sim_identity 调 AT 并缓存 ----
+
+def _make_modem(monkeypatch, responses: dict):
+    from agentcall import modem as modem_mod
+    from agentcall.modem import Eg25Modem
+
+    m = Eg25Modem("unused")
+    monkeypatch.setattr(m, "_send", lambda cmd: responses.get(cmd, "OK"))
+    monkeypatch.setattr(modem_mod.time, "sleep", lambda s: None)  # 免真 sleep
+    return m
+
+
+def test_modem_refresh_caches_and_logs(monkeypatch, caplog):
+    modem = _make_modem(monkeypatch, {
+        "AT+CIMI": "460030123456789\r\nOK",
+        "AT+CREG?": "+CREG: 0,1\r\nOK",
+    })
+    with caplog.at_level("INFO"):
+        modem.refresh_sim_identity()
+    sim = modem.sim_identity
+    assert sim.carrier == "中国电信" and sim.service_number == "10000"
+    assert sim.registered
+    assert any("SIM 识别" in r.message for r in caplog.records)
+    assert not any("460030123456789" in r.getMessage() for r in caplog.records)  # 日志无完整 IMSI
+
+
+def test_modem_refresh_at_logic_failure_degrades(monkeypatch):
+    """AT 返回 ERROR / 非传输层异常 → 降级 UNKNOWN,不抛(主链路不受影响)。"""
+
+    modem = _make_modem(monkeypatch, {"AT+CIMI": "+CME ERROR: SIM not inserted",
+                                       "AT+CREG?": "+CREG: 0,2"})
+    modem.refresh_sim_identity()  # 不抛
+    assert not modem.sim_identity.present and modem.sim_identity.reg_status == "搜网中"
+
+
+def test_modem_refresh_serial_error_propagates(monkeypatch):
+    """BLOCK-3 回归锁:传输层异常必须上抛给 _open_serial 退避循环,
+    绝不能吞成'识别失败'让重连误判成功。"""
+    import pytest
+    import serial
+
+    from agentcall import modem as modem_mod
+    from agentcall.modem import Eg25Modem
+
+    m = Eg25Modem("unused")
+    monkeypatch.setattr(modem_mod.time, "sleep", lambda s: None)
+
+    def dead(cmd):
+        raise serial.SerialException("device disconnected")
+
+    monkeypatch.setattr(m, "_send", dead)
+    with pytest.raises(serial.SerialException):
+        m.refresh_sim_identity()
+
+
+def test_modem_refresh_retries_cimi_power_up_delay(monkeypatch):
+    """SIM 上电延迟:前两次 CIMI 空/ERROR,第三次成功 → 最终识别到卡。"""
+    from agentcall import modem as modem_mod
+    from agentcall.modem import Eg25Modem
+
+    m = Eg25Modem("unused")
+    monkeypatch.setattr(modem_mod.time, "sleep", lambda s: None)
+    seq = iter(["ERROR", "ERROR", "460080123456789\r\nOK"])
+    calls = {"creg": "+CREG: 0,1\r\nOK"}
+    def fake_send(cmd):
+        return next(seq) if cmd == "AT+CIMI" else calls["creg"]
+    monkeypatch.setattr(m, "_send", fake_send)
+    m.refresh_sim_identity()
+    assert m.sim_identity.present and m.sim_identity.carrier == "中国移动"
+
+
+def test_modem_default_identity_before_connect():
+    from agentcall.modem import Eg25Modem
+    from agentcall.sim_identity import UNKNOWN_SIM
+
+    assert Eg25Modem("unused").sim_identity == UNKNOWN_SIM

--- a/tests/unit/test_web_api.py
+++ b/tests/unit/test_web_api.py
@@ -1503,3 +1503,75 @@ def test_auth_disabled_when_token_none_keeps_loopback_behavior():
         return resp.status
 
     assert api(app, fn) == 200
+
+
+def test_meta_omits_sim_when_no_modem():
+    """service 无 modem → /api/meta 不含 sim 键,不炸(#88 边界)。"""
+    service = FakeService()
+    app = build_app(
+        hub=None,  # type: ignore[arg-type]
+        modem=None,  # type: ignore[arg-type]
+        service=service,
+        meta={"provider": "qwen"},
+    )
+
+    async def fn(client):
+        resp = await client.get("/api/meta")
+        assert resp.status == 200
+        return await resp.json()
+
+    assert "sim" not in api(app, fn)
+
+
+def test_meta_exposes_sim_without_full_imsi():
+    """/api/meta 透出 sim 块,含运营商/客服号,绝不含完整 IMSI(#88 隐私)。"""
+    import json as _json
+
+    from agentcall.sim_identity import identify
+
+    class _FakeModem:
+        sim_identity = identify("460110123456789\r\nOK", "+CREG: 0,1")
+
+    service = FakeService()
+    service.modem = _FakeModem()  # type: ignore[attr-defined]
+    app = build_app(
+        hub=None,  # type: ignore[arg-type]
+        modem=None,  # type: ignore[arg-type]
+        service=service,
+        meta={"provider": "qwen"},
+    )
+
+    async def fn(client):
+        resp = await client.get("/api/meta")
+        assert resp.status == 200
+        return await resp.json()
+
+    meta = api(app, fn)
+    assert meta["sim"]["carrier"] == "中国电信"
+    assert meta["sim"]["service_number"] == "10000"
+    assert meta["sim"]["plmn"] == "46011"
+    assert "460110123456789" not in _json.dumps(meta, ensure_ascii=False)
+
+
+def test_meta_exposes_unknown_sim_block():
+    """无卡时 sim 块仍在(present=False),UI 可显示'未插卡'(#88)。"""
+    from agentcall.sim_identity import UNKNOWN_SIM
+
+    class _FakeModem:
+        sim_identity = UNKNOWN_SIM
+
+    service = FakeService()
+    service.modem = _FakeModem()  # type: ignore[attr-defined]
+    app = build_app(
+        hub=None,  # type: ignore[arg-type]
+        modem=None,  # type: ignore[arg-type]
+        service=service,
+        meta={"provider": "qwen"},
+    )
+
+    async def fn(client):
+        resp = await client.get("/api/meta")
+        return await resp.json()
+
+    sim = api(app, fn)["sim"]
+    assert sim["present"] is False and sim["carrier"] == "未知"


### PR DESCRIPTION
#88 第一步(诊断层):连接/重连后读 IMSI+CREG,PLMN 前缀映射四大运营商(移动/联通/电信/广电)与免费客服号,缓存 modem.sim_identity;/api/meta 透出 sim 块;设置页硬件面板加 SIM 行(运营商·注册状态·客服号)。**换卡误拨跨网客服计费、未注册拨号 45s 白等**两个真花过钱/时间的坑,先有了可视诊断。

**范围诚实声明**:本批只做「识别+展示」,不消费到拨号(误拨拦截/未注册快速失败)、不做不拔卡热换卡的 URC 持续刷新——这两项拆 follow-up,故 \`Refs #88\` 不 Closes。

**codex 双轮 review:BLOCK → APPROVE**(cpair,headless):
- BLOCK-3(核心 bug)闭环:传输层异常(SerialException/OSError)上抛给退避循环,不再吞成识别失败让重连误判成功;仅 AT 逻辑/解析失败降级。含回归测试。
- BLOCK-1 降级可接受:CIMI 短重试覆盖上电延迟 + 公开 refresh 入口 + docstring 标注 URC 限制。
- BLOCK-2:措辞降级为诊断层,拨号拦截拆 follow-up。
- 补广电 46015→10099、3 个 /api/meta 边界测试。

隐私:全路径只留 PLMN 前 5 位,绝不落完整 IMSI(多测试锁死)。
测试:sim_identity 16 + /api/meta 3;全量 859 passed / ruff / mypy 绿。

Refs #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3ym8uHa4Xq46rZBDCXaDb