### PR TITLE
feat(openai): OpenAI 说话 Vibe 选择器（OPENAI_VIBE）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,9 @@ OPENAI_API_KEY=
 OPENAI_REALTIME_MODEL=gpt-realtime-2.1-mini
 # 音色：alloy、ash、cedar、coral、marin 等
 OPENAI_VOICE=alloy
+# OpenAI 说话 Vibe（仅 OpenAI 链路）：追加在 VOICE_STYLE 之后并入 instructions。
+# 空=不追加；可选 calm、cheerful、professional、warm、energetic。参考 https://openai.fm 的 VIBE。
+OPENAI_VIBE=
 # Realtime 端点覆写（可选，wss 地址 base，留空 = 直连 wss://api.openai.com/v1/realtime）。
 # 仅在用反代 / Azure OpenAI，或所在网络无法直连 OpenAI 时才需要填。
 OPENAI_REALTIME_URL=

--- a/src/agentcall/agents/openai_agent.py
+++ b/src/agentcall/agents/openai_agent.py
@@ -23,7 +23,7 @@ from typing import Any, Callable
 import websockets
 
 from .. import config
-from ..prompts import agent_language, repeat_nudge_instructions
+from ..prompts import agent_language, openai_vibe_line, repeat_nudge_instructions
 from ..repeat_suppression import ResponseAudioGate
 from .base import VoiceAgent
 from .tools import SILENT_AFTER_TOOLS, TERMINAL_TOOLS
@@ -196,6 +196,10 @@ class OpenAIVoiceAgent(VoiceAgent):
         self._manual_response_enabled = config.get_bool("MANUAL_RESPONSE_CONTROL")
         self._reset_manual_response_state()
         self._instructions = self._session_instructions or _default_instructions()
+        # OpenAI-only 说话 Vibe：追加在 VOICE_STYLE（已并入上面的 instructions）之后。
+        vibe_line = openai_vibe_line()
+        if vibe_line:
+            self._instructions = f"{self._instructions.rstrip()}\n{vibe_line}"
         await self._connect()
         self._recv_task = asyncio.create_task(self._recv_loop())
 

--- a/src/agentcall/config.py
+++ b/src/agentcall/config.py
@@ -172,6 +172,14 @@ CONFIG_SPECS: tuple[ConfigSpec, ...] = (
                choices=("alloy", "ash", "ballad", "coral", "echo",
                         "sage", "shimmer", "verse", "marin", "cedar"),
                help="https://openai.fm"),
+    # OpenAI 说话 Vibe（仅 OpenAI 链路）：选中后其风格描述追加在 VOICE_STYLE
+    # 之后一并注入会话 instructions（见 prompts.openai_vibe_line 与 openai_agent）。
+    # 空 = 不追加，行为与旧版一致；qwen 链路不受影响。参考 https://openai.fm 的 VIBE。
+    ConfigSpec("OPENAI_VIBE", "OpenAI 说话 Vibe", "select", "",
+               choices=("", "calm", "cheerful", "professional",
+                        "warm", "energetic"),
+               choice_labels={"": "（默认·不追加）"},
+               help="https://openai.fm"),
     # 端点覆写（可选）：留空即直连 api.openai.com；仅在用反代/Azure OpenAI，
     # 或所在网络无法直连 OpenAI 时才需要填。
     ConfigSpec("OPENAI_REALTIME_URL", "OpenAI Realtime 端点覆写", "str", "",

--- a/src/agentcall/prompts.py
+++ b/src/agentcall/prompts.py
@@ -45,6 +45,21 @@ def agent_language() -> str:
     return normalize_lang(config.get_str("AGENT_LANGUAGE"))
 
 
+def openai_vibe_line(lang: str | None = None) -> str:
+    """OpenAI-only 说话 Vibe：追加在 ``VOICE_STYLE`` 之后的一行风格补充。
+
+    读取 config ``OPENAI_VIBE``；为空则返回空串（不追加）。仅由 openai_agent 在
+    装配 OpenAI 会话 instructions 时调用，qwen/doubao/local 链路不受影响。``lang``
+    缺省按 ``AGENT_LANGUAGE``。
+    """
+    vibe = config.get_str("OPENAI_VIBE").strip()
+    if not vibe:
+        return ""
+    if (lang or agent_language()) == "en":
+        return f"Additional speaking style: {vibe}."
+    return f"机主希望的说话风格补充：{vibe}。"
+
+
 def owner_name(lang: str = "zh") -> str:
     """机主称谓；OWNER_NAME 未设置时用当前语言的中性称谓。"""
     return config.get_str("OWNER_NAME").strip() or _OWNER_FALLBACK[normalize_lang(lang)]

--- a/src/agentcall/web/static/index.html
+++ b/src/agentcall/web/static/index.html
@@ -1329,7 +1329,7 @@ const I18N = {
       AGENT_PROVIDER: "Agent provider", DASHSCOPE_API_KEY: "DashScope API key",
       QWEN_REALTIME_MODEL: "Qwen realtime model", QWEN_VOICE: "Qwen voice",
       OPENAI_API_KEY: "OpenAI API key",
-      OPENAI_REALTIME_MODEL: "OpenAI realtime model", OPENAI_VOICE: "OpenAI voice",
+      OPENAI_REALTIME_MODEL: "OpenAI realtime model", OPENAI_VOICE: "OpenAI voice", OPENAI_VIBE: "OpenAI vibe",
       OPENAI_REALTIME_URL: "OpenAI endpoint override", OPENAI_RECONNECT_MAX: "OpenAI max reconnects",
       AGENT_OUTBOUND_TASK: "Default outbound topic",
       OWNER_NAME: "Owner name", AGENT_PERSONA: "AI persona title",

--- a/tests/unit/test_openai_agent.py
+++ b/tests/unit/test_openai_agent.py
@@ -189,6 +189,45 @@ def test_session_instructions_override_default(monkeypatch):
     asyncio.run(scenario())
 
 
+def test_openai_vibe_appends_to_session_instructions(monkeypatch):
+    """OPENAI_VIBE 非空时，其风格补充追加在会话 instructions 末尾（VOICE_STYLE 之后）。"""
+    monkeypatch.setenv("AGENT_LANGUAGE", "zh")
+    monkeypatch.setenv("OPENAI_VIBE", "cheerful")
+    instances, _calls = _patch_connect(monkeypatch)
+    agent = _make_agent()
+    agent.set_session_instructions("外呼任务：确认预约")
+
+    async def scenario():
+        await agent.start(lambda pcm: None)
+        try:
+            session = instances[0].sent[0]["session"]
+            assert session["instructions"] == (
+                "外呼任务：确认预约\n机主希望的说话风格补充：cheerful。"
+            )
+        finally:
+            await agent.stop()
+
+    asyncio.run(scenario())
+
+
+def test_openai_vibe_empty_leaves_instructions_unchanged(monkeypatch):
+    """OPENAI_VIBE 为空(默认)时不追加，instructions 与传入保持一致。"""
+    monkeypatch.setenv("OPENAI_VIBE", "")
+    instances, _calls = _patch_connect(monkeypatch)
+    agent = _make_agent()
+    agent.set_session_instructions("外呼任务：确认预约")
+
+    async def scenario():
+        await agent.start(lambda pcm: None)
+        try:
+            session = instances[0].sent[0]["session"]
+            assert session["instructions"] == "外呼任务：确认预约"
+        finally:
+            await agent.stop()
+
+    asyncio.run(scenario())
+
+
 def test_manual_response_control_sets_create_response_false_and_debounces(monkeypatch):
     monkeypatch.setenv("MANUAL_RESPONSE_CONTROL", "true")
     monkeypatch.setenv("MANUAL_RESPONSE_SILENCE_MS", "25")

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -6,6 +6,7 @@ from agentcall.prompts import (
     DEFAULT_OUTBOUND_TASK,
     agent_persona,
     build_instructions,
+    openai_vibe_line,
     opening_instructions,
     owner_name,
 )
@@ -24,6 +25,25 @@ def test_owner_and_persona_defaults(monkeypatch):
     monkeypatch.delenv("AGENT_PERSONA", raising=False)
     assert owner_name() == "机主"
     assert agent_persona() == "AI 助理"
+
+
+# ---- OpenAI 说话 Vibe（仅 OpenAI 链路）----
+
+def test_openai_vibe_line_empty_returns_blank(monkeypatch):
+    monkeypatch.setenv("OPENAI_VIBE", "  ")
+    assert openai_vibe_line() == ""
+
+
+def test_openai_vibe_line_zh_and_en(monkeypatch):
+    monkeypatch.setenv("OPENAI_VIBE", "calm")
+    assert openai_vibe_line("zh") == "机主希望的说话风格补充：calm。"
+    assert openai_vibe_line("en") == "Additional speaking style: calm."
+
+
+def test_openai_vibe_line_defaults_to_agent_language(monkeypatch):
+    monkeypatch.setenv("OPENAI_VIBE", "cheerful")
+    monkeypatch.setenv("AGENT_LANGUAGE", "en")
+    assert openai_vibe_line() == "Additional speaking style: cheerful."
 
 
 # ---- 系统提示词 ----


### PR DESCRIPTION
## 概述
新增 OpenAI-only 说话 Vibe 选择器 `OPENAI_VIBE`：OpenAI 通话时把选中风格**追加在 `VOICE_STYLE` 之后**并入会话 instructions；`qwen` / `doubao` / `local` 链路不受影响。

Closes #106

## 改动
- **config**：`OPENAI_VIBE` select（空 = 不追加）+ `choice_labels` + `.env.example` 同步
- **prompts**：`openai_vibe_line()` 按 `AGENT_LANGUAGE` 生成风格补充行（zh/en）
- **openai_agent**：仅 OpenAI 在装配 session instructions 时追加 vibe
- **web**：设置面板 i18n 标签（下拉自动从 `/api/config` 渲染）
- **tests**：5 项（prompts 纯函数 zh/en/空 + openai_agent 会话注入）

## 设计要点
- **仅 OpenAI 生效**：注入点在 `openai_agent.start()` 装配 instructions 处，OpenAI-only 隔离。
- **与 `VOICE_STYLE` 关系**：追加（VOICE_STYLE 在前、vibe 在后），保留共享自由文本风格。
- **前端零硬编码**：select 从 `/api/config` 自动渲染，只补一条 en i18n 标签。

## 验证
- 质量门全绿（本地）：`pytest -q` → **1079 passed, 3 skipped**；`ruff check .` clean；`mypy` clean。
- 运行时自测：重启服务后 `/api/config` 正确暴露 `OPENAI_VIBE`；dashboard 下拉可选、空项显示「（默认·不追加）」。
- 本 PR 只改 instructions 装配，不动音频/AT 链路。

## 评审
碰到通话链路（`openai_agent` instructions 装配），请 @tianye1999 过一轮 CR 后再合并。

🤖 Generated with [Claude Code](https://claude.com/claude-code)