### PR TITLE
fix(WIL-90): 单轮长度闸门改为截断下行——原实现真机上完全无效

### DIFF
--- a/src/agentcall/call_agent.py
+++ b/src/agentcall/call_agent.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import math
 import os
@@ -612,7 +613,19 @@ class CallSession:
             # 重则护窗一旦长过 _TURN_GAP_SECONDS，下一块就被当成新一轮而清零计数，
             # 跑飞的长轮次就此绕过闸门。而这恰恰是 IVR 路径——模型边按键边说话
             # 正是 WIL-49 记录在案的行为。
-            self._check_turn_length(pcm_agent, agent, record)
+            if self._check_turn_length(pcm_agent, agent, record):
+                # 本轮已超上限：**丢掉后续下行**。这才是真正的闸门。
+                #
+                # 2026-08-06 真机验证（拨 10086）证明「靠 response.cancel 掐生成」
+                # 完全无效：OpenAI 把整轮音频以突发写完的速度，快过我们按字节
+                # 累计到阈值——事件记了 turn_length_capped、日志写了「打断本轮」，
+                # 而 provider 回的是 response_cancel_not_active（响应早就结束了），
+                # 队列照常放完，对端把 14.4s 和 29.6s 的两轮整段听完了。
+                #
+                # 要限制的是**对端听到多久**，就必须在「送进下行队列」这一步拦，
+                # 不能指望上游停止生成。DTMF 双音走 _send_dtmf_raw 单独入队，
+                # 不经过这里，所以 WIL-49 的按键不受影响。
+                return
             # 按键护窗：DTMF 期间丢弃 Agent 下行，别让语音和双音挤在同一段上行。
             # 真机 2026-08-03 拨 10086：模型一边说「这边先按一下对应的键」一边按，
             # 4 次本机 success、IVR 菜单一次没推进（见 #45 评论）。
@@ -2029,8 +2042,8 @@ class CallSession:
 
     def _check_turn_length(
         self, pcm_agent: bytes, agent: VoiceAgent, record: CallRecord | None
-    ) -> None:
-        """单轮长度闸门（WIL-90 / WIL-85 N2）：一轮生成过长就打断生成。
+    ) -> bool:
+        """单轮长度闸门（WIL-90 / WIL-85 N2）。返回 True 表示**这块下行要丢掉**。
 
         为什么必须有这个闸门，而不能只在提示词里写「说短点」：WIL-83 已实测
         证明模型**不可靠地遵守**提示词里的禁令——受限话术明令禁止「说会转告」，
@@ -2039,52 +2052,53 @@ class CallSession:
         分工：提示词负责把中位数压下来，这里只兜住跑飞的长尾
         （WIL-89 基线：中位 6.8s、p90 17.8s、最长 36.6s；默认阈值 20s）。
 
-        掐生成不掐播放——已排队的音频照常播完，对端听到的是完整播出的一段，
-        而不是被硬切掉半个字。
+        **截断靠丢弃下行，不靠 provider 停止生成。** 2026-08-06 真机验证推翻了
+        原设计：OpenAI 把整轮音频以突发写完的速度快过我们累计到阈值，等闸门
+        触发时响应早已结束，response.cancel 直接返回 response_cancel_not_active，
+        队列照常放完——对端把 14.4s 和 29.6s 的两轮整段听完了，而事件流里却记着
+        turn_length_capped。所以限制必须落在「送不送进下行队列」这一步。
+
+        代价要说清：这是**硬切**，被截的那一轮结尾会突兀。默认阈值取在实测
+        p90 之上就是为了让它只在明显跑飞时才触发。
         """
         if self._max_turn_seconds <= 0 or not pcm_agent:
-            return
+            return False
         rate = getattr(agent, "output_rate", 0) or self._agent_output_rate
         if rate <= 0:
-            return
+            return False
         now = time.monotonic()
         with self._turn_lock:
             if now - self._turn_last_chunk_at > self._TURN_GAP_SECONDS:
-                # 空档 → 新的一轮，计数与「已打断」标志一起重置。
+                # 空档 → 新的一轮，计数与「已超限」标志一起重置。
                 self._turn_audio_bytes = 0
                 self._turn_cancel_sent = False
             self._turn_last_chunk_at = now
+            if self._turn_cancel_sent:
+                return True  # 本轮已超限，后续分块一律丢弃
             self._turn_audio_bytes += len(pcm_agent)
             seconds = self._turn_audio_bytes / (rate * 2)
-            if seconds <= self._max_turn_seconds or self._turn_cancel_sent:
-                return
-
-        # 先确认打断真的派发出去了，再置「已打断」标志、再落事件。
-        # 反过来（先置标志再派发）的话，事件流会显示「已掐断」而实际什么都没发生，
-        # 且这一轮之后再也不会重试——又是一次静默失效（2026-08-05 Codex 评审 P2）。
-        loop = self._loop
-        if loop is None or not loop.is_running():
-            logger.warning(
-                "单轮生成超过 %.1fs，但事件循环不可用，本轮无法打断",
-                self._max_turn_seconds,
-            )
-            return
-        try:
-            asyncio.run_coroutine_threadsafe(self._cancel_agent_turn(agent), loop)
-        except RuntimeError as exc:
-            logger.warning("派发打断失败: %s", exc)
-            return
-
-        with self._turn_lock:
-            # 一轮只打断一次：cancel 之后余下的分块还会到，不设标志会反复下发。
+            if seconds <= self._max_turn_seconds:
+                return False
             self._turn_cancel_sent = True
-        logger.info("单轮生成超过 %.1fs，打断本轮", self._max_turn_seconds)
+
+        # 闸门本身**已经生效**（调用方会丢掉这块及之后的下行）。下面再顺手请
+        # provider 停止生成，纯属省 token / 省时延——**不是**限制生效的手段。
+        #
+        # 2026-08-06 真机验证：靠 response.cancel 掐生成完全无效，OpenAI 早在
+        # 我们累计到阈值之前就把整轮生成完了，回的是 response_cancel_not_active。
+        # 所以这里不再因为它失败而告警——那是预期内的常态，不是故障。
+        logger.info("单轮已达 %.1fs 上限，截断本轮剩余下行", self._max_turn_seconds)
         if record is not None:
             record.log_event(
                 "turn_length_capped",
                 seconds=round(seconds, 1),
                 limit=self._max_turn_seconds,
             )
+        loop = self._loop
+        if loop is not None and loop.is_running():
+            with contextlib.suppress(RuntimeError):
+                asyncio.run_coroutine_threadsafe(self._cancel_agent_turn(agent), loop)
+        return True
 
     async def _cancel_agent_turn(self, agent: VoiceAgent) -> None:
         """把打断真正下发给 provider，并记录它到底有没有生效。
@@ -2098,9 +2112,8 @@ class CallSession:
             logger.warning("打断本轮回复异常: error_type=%s", type(exc).__name__)
             return
         if not delivered:
-            logger.warning(
-                "单轮长度闸门未生效：当前 provider 不支持打断，长轮次不会被掐断"
-            )
+            # 只是没省下这点生成而已；截断由调用方丢弃下行完成，不受影响。
+            logger.debug("本 provider 未接受打断请求（不影响截断生效）")
 
     def _flush_dtmf_guard_drop(self, record: CallRecord | None, rate: int) -> None:
         """护窗结束后落一条「丢了多少 Agent 语音」的事件。

--- a/tests/unit/test_turn_length_gate.py
+++ b/tests/unit/test_turn_length_gate.py
@@ -233,21 +233,31 @@ def test_extra_chunks_do_not_dispatch_more_cancels():
     assert asyncio.run(scenario()).cancel_calls == 1
 
 
-def test_no_running_loop_warns_and_does_not_mark_capped(caplog):
-    """没有可用事件循环时，不能假装掐断了。
+def test_truncation_works_without_an_event_loop():
+    """没有事件循环也照样截断。
 
-    先置标志再派发的话，事件流显示「已掐断」而实际什么都没发生，且这一轮之后
-    再也不会重试——静默失效。
+    截断是靠**丢弃下行**完成的，与能不能给 provider 发 cancel 无关。
+    2026-08-06 真机验证正是这一条：cancel 被 provider 拒了
+    （response_cancel_not_active），若截断依赖它，闸门就完全失效。
     """
     session = make_session(limit=3.0)
     session._loop = None
     agent, record = RecordingAgent(), Events()
-    with caplog.at_level("WARNING"):
-        feed(session, agent, record, agent.output_rate, seconds=6.0)
 
-    assert session._turn_cancel_sent is False, "没派发出去就不能标成已打断"
-    assert record.capped() == [], "没真的打断就不该落 turn_length_capped"
-    assert any("无法打断" in r.getMessage() for r in caplog.records)
+    dropped = []
+    remaining = 6.0
+    while remaining > 1e-9:
+        step = min(0.5, remaining)
+        dropped.append(
+            session._check_turn_length(
+                seconds_of(agent.output_rate, step), agent, record
+            )
+        )
+        remaining -= step
+
+    assert any(dropped), "超限后必须开始丢弃下行"
+    assert session._turn_cancel_sent is True
+    assert record.capped(), "截断已发生，事件必须落"
 
 
 # ---- 护窗期内生成的音频也要计入（Codex 评审 P1）----
@@ -280,26 +290,34 @@ def test_audio_generated_during_dtmf_guard_still_counts():
 # ---- 静默失效防护（WIL-75 的形态）----
 
 
-def test_unsupported_provider_is_warned_not_silent(caplog):
-    """provider 不支持打断时必须**大声说出来**。
+def test_truncation_is_independent_of_cancel_being_accepted():
+    """provider 拒绝 cancel 时，截断仍然必须生效。
 
-    豆包就没有实现这条能力。不区分「已下发」与「不支持」，闸门就会变成
-    又一次静默失效——事件照落、日志照打、实际什么都没发生。
+    这是 2026-08-06 真机验证的核心教训：OpenAI 回 response_cancel_not_active，
+    而原实现把截断寄托在 cancel 上，于是事件记了 turn_length_capped、对端却把
+    14.4s 和 29.6s 的两轮整段听完了。
     """
+    session = make_session(limit=3.0)
+    agent, record = RecordingAgent(delivered=False), Events()
+
+    dropped = [
+        session._check_turn_length(
+            seconds_of(agent.output_rate, 0.5), agent, record
+        )
+        for _ in range(12)
+    ]
+    assert any(dropped), "provider 不接受 cancel 时，截断依然要靠丢弃下行生效"
+    assert record.capped()
+
+
+def test_cancel_rejection_is_not_a_warning(caplog):
+    """cancel 被拒是**常态**不是故障：闸门不依赖它，不该刷 WARNING。"""
     session = make_session(limit=5.0)
     agent = RecordingAgent(delivered=False)
     with caplog.at_level("WARNING"):
         asyncio.run(session._cancel_agent_turn(agent))
     assert agent.cancel_calls == 1
-    assert any("不支持打断" in r.getMessage() for r in caplog.records)
-
-
-def test_delivered_cancel_is_quiet(caplog):
-    session = make_session(limit=5.0)
-    agent = RecordingAgent(delivered=True)
-    with caplog.at_level("WARNING"):
-        asyncio.run(session._cancel_agent_turn(agent))
-    assert not [r for r in caplog.records if "不支持打断" in r.getMessage()]
+    assert not [r for r in caplog.records if r.levelname == "WARNING"]
 
 
 def test_cancel_exception_does_not_escape():


### PR DESCRIPTION
真机验收发现昨晚合入的 WIL-90 闸门**在生产上是死的**，本 PR 修复。

## 缺陷

2026-08-06 拨 10086（阈值临时调 5s）：

```
11:43:17,394 [下行·Agent] 感谢你接听。我这边代表William，想查询…（整段）
11:43:17,396 单轮生成超过 5.0s，打断本轮
11:43:17,775 [ERROR] response_cancel_not_active
                     'Cancellation failed: no active response found'
```

事件流记了 3 次 `turn_length_capped`，对端却把 **14.4s 和 29.6s** 的两轮整段听完了。

**根因是因果搞反了。** 原设计论证「生成快于播放，所以按已生成字节判、掐生成」——但正因为生成快，等累计到阈值时整轮早已生成完毕，`response.cancel` 找不到活跃响应。要限制「对端听到多久」，只能在**送不送进下行队列**这一步拦。

## 改法

`_check_turn_length` 返回「这块是否丢弃」，`on_agent_audio` 直接丢掉超限之后的下行。cancel 仍发但降级为省 token 的尽力而为，被拒不再告警。

DTMF 双音走 `_send_dtmf_raw` 单独入队、不经此路径，WIL-49 不受影响。

## 同一硬件同一阈值复测

| | 单轮时长 (ms) | 最长 |
| -- | -- | -- |
| 修复前 | `[14450, 4100, 2800, 1600, 1200, 29550]` | **29550** ❌ |
| 修复后 | `[4800, 4600, 3200, 4800, 800, 4150, 4800, 4800]` | **4800** ✅ |

四轮落在 4800ms —— 跨过 5000ms 前的最后一块，闸门在收口。

**WIL-49 未回归**：按 `1` 后对端「回廣東一零零八六,請稍候」，菜单实际推进（判据取自对端，非本机 `result:success`）。

## 代价

硬切，被截那一轮结尾会突兀。默认阈值 20s 取在实测 p90 (17.8s) 之上正是为此。

质量门：1342 passed · ruff · mypy darwin/linux/win32。

🤖 Generated with [Claude Code](https://claude.com/claude-code)